### PR TITLE
enhancement: added latex expression wrapping

### DIFF
--- a/frontend/components/MarkdownMessage.tsx
+++ b/frontend/components/MarkdownMessage.tsx
@@ -4,6 +4,17 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 
+function wrapExpressions(text: string): string {
+  // wraps "\n[...\n]" for own line formulas
+  text = text.replace(/(?:^|\n)\[\n([\s\S]+?)\n\](?:\n|$)/g, (_, inner) => `\n$$\n${inner.trim()}\n$$\n`);
+
+  // wraps inline \(...\) or \[...\]
+  text = text.replace(/\\\((.+?)\\\)/gs, (_, inner) => `$${inner.trim()}$`);
+  text = text.replace(/\\\[(.+?)\\\]/gs, (_, inner) => `$${inner.trim()}$`);
+
+  return text;
+}
+
 const schema = {
   ...defaultSchema,
   attributes: {
@@ -23,6 +34,8 @@ const schema = {
 };
 
 export default function MarkdownMessage({ content }: { content: string }) {
+  const wrapped_content = wrapExpressions(content);
+
   return (
     <div className="prose prose-sm max-w-none">
       <ReactMarkdown
@@ -32,7 +45,7 @@ export default function MarkdownMessage({ content }: { content: string }) {
           rehypeKatex,
         ]}
       >
-        {content}
+        {wrapped_content}
       </ReactMarkdown>
     </div>
   );


### PR DESCRIPTION
Issue #49 

LaTeX expressions were not rendering correctly, since they were being incorrectly wrapped. Implemented a wrapper function, wrapExpressions(text), that uses regex to parse any instances of the incorrect delimitation and replaces them with correct LaTeX delimiters. Incorrect delimiters are not used in normal prose by the AI assistant, so false LaTeX formatting shouldn't be an issue.

Output was correctly formatted for all of my testing.

