### PR TITLE
Improvements to Link Case + Routing fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ UF_SEARCH_TOOL_NAME=litellm-search
 MONGO_URL=mongodb://localhost:27017
 
 # Database name
-MONGO_DB=m
+MONGO_DB=
 
 # -----------------------------------------------------------------------
 # Auth / Session

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,53 @@
+# -----------------------------------------------------------------------
+# UF NaviGator AI (OpenAI-compatible proxy)
+# -----------------------------------------------------------------------
+
+# API key for the UF NaviGator AI proxy — required for all chat and search
+UF_OPENAI_API_KEY=
+
+# Base URL of the UF proxy (default is correct for UF, override if self-hosting)
+UF_OPENAI_BASE_URL=https://api.ai.it.ufl.edu
+
+# Model name served by the proxy (e.g. gpt-4o, gpt-4-turbo)
+UF_OPENAI_API_MODEL=
+
+# Search tool name registered in the LiteLLM router (default matches UF config)
+UF_SEARCH_TOOL_NAME=litellm-search
+
+# -----------------------------------------------------------------------
+# MongoDB
+# -----------------------------------------------------------------------
+
+# Connection string — use mongodb://mongo:27017 when running via docker-compose
+MONGO_URL=mongodb://localhost:27017
+
+# Database name
+MONGO_DB=
+
+# -----------------------------------------------------------------------
+# Auth / Session
+# -----------------------------------------------------------------------
+
+# Secret used to sign JWT tokens — change this to a long random string in production
+# Generate one with: openssl rand -hex 32
+JWT_SECRET=dev-secret-change-me
+
+# Token lifetime in minutes (default 180 = 3 hours)
+JWT_EXPIRES_MIN=180
+
+# Set to true in production (HTTPS only) — keep false for local development
+COOKIE_SECURE=false
+
+# Cookie domain — leave blank for localhost; set to your domain in production (e.g. .example.com)
+COOKIE_DOMAIN=
+
+# SameSite policy: Lax (default) works for same-origin; use None for cross-site (requires COOKIE_SECURE=true)
+COOKIE_SAMESITE=Lax
+
+# -----------------------------------------------------------------------
+# CORS / Frontend
+# -----------------------------------------------------------------------
+
+# Publicly accessible frontend URL — required in production to allow cross-origin requests
+# e.g. https://your-app.herokuapp.com
+FRONTEND_ORIGIN=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,53 @@
+# -----------------------------------------------------------------------
+# UF NaviGator AI (OpenAI-compatible proxy)
+# -----------------------------------------------------------------------
+
+# API key for the UF NaviGator AI proxy — required for all chat and search
+UF_OPENAI_API_KEY=
+
+# Base URL of the UF proxy (default is correct for UF, override if self-hosting)
+UF_OPENAI_BASE_URL=https://api.ai.it.ufl.edu
+
+# Model name served by the proxy (e.g. gpt-4o, gpt-4-turbo)
+UF_OPENAI_API_MODEL=
+
+# Search tool name registered in the LiteLLM router (default matches UF config)
+UF_SEARCH_TOOL_NAME=litellm-search
+
+# -----------------------------------------------------------------------
+# MongoDB
+# -----------------------------------------------------------------------
+
+# Connection string — use mongodb://mongo:27017 when running via docker-compose
+MONGO_URL=mongodb://localhost:27017
+
+# Database name
+MONGO_DB=m
+
+# -----------------------------------------------------------------------
+# Auth / Session
+# -----------------------------------------------------------------------
+
+# Secret used to sign JWT tokens — change this to a long random string in production
+# Generate one with: openssl rand -hex 32
+JWT_SECRET=dev-secret-change-me
+
+# Token lifetime in minutes (default 180 = 3 hours)
+JWT_EXPIRES_MIN=180
+
+# Set to true in production (HTTPS only) — keep false for local development
+COOKIE_SECURE=false
+
+# Cookie domain — leave blank for localhost; set to your domain in production (e.g. .example.com)
+COOKIE_DOMAIN=
+
+# SameSite policy: Lax (default) works for same-origin; use None for cross-site (requires COOKIE_SECURE=true)
+COOKIE_SAMESITE=Lax
+
+# -----------------------------------------------------------------------
+# CORS / Frontend
+# -----------------------------------------------------------------------
+
+# Publicly accessible frontend URL — required in production to allow cross-origin requests
+# e.g. https://your-app.herokuapp.com
+FRONTEND_ORIGIN=

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -18,7 +18,7 @@ from ..schemas.chat import (
 )
 from .auth import get_current_user
 from ..services.chat import get_last_exchange, get_conversation_history as fetch_conversation_history
-from ..services.search import prepare_search_messages, _inject_citation_links
+from ..services.search import _run_search, _filter_valid_urls, _build_search_context, _inject_citation_links
 from ..services.followup import generate_followup_questions
 
 router = APIRouter()
@@ -397,29 +397,46 @@ async def chat_with_embedded_links(
     )
 
     async def generate() -> AsyncGenerator[str, None]:
+        # Run search first — results are needed to build AI context
         try:
-            augmented_messages, citations = await prepare_search_messages(
-                messages=_build_standard_messages(history, req.message, system_prompt=system_instruction),
-                db_links=getattr(request.app.state, "knowledge_links", []),
-            )
+            raw_web = await _run_search(req.message)
         except Exception as e:
             yield _sse({"type": "error", "detail": f"Search failed: {e}"})
             return
 
-        # Send validated citation map before tokens so frontend has it ready
+        curated = [
+            {"title": l.get("title", ""), "url": l.get("url", ""), "snippet": l.get("description", "")}
+            for l in getattr(request.app.state, "knowledge_links", [])
+            if l.get("url")
+        ]
+        augmented_messages, citations = _build_search_context(
+            _build_standard_messages(history, req.message, system_prompt=system_instruction),
+            curated + raw_web,
+        )
+
+        # Kick off URL validation as a background task so it runs while tokens stream.
+        # The AI already has all results as context; validation only affects which
+        # citation links get injected into the stored reply at the end.
+        validation_task = asyncio.create_task(_filter_valid_urls(raw_web))
+
         if citations:
             yield _sse({"type": "citations", "citations": citations})
 
-        # Real token streaming
         full_reply = ""
         async for is_error, delta, sse in _stream_agent_tokens(augmented_messages):
             yield sse
             if is_error:
+                validation_task.cancel()
                 return
             full_reply += delta
 
-        # Inject citations into the stored copy so history loads with working links
-        stored_reply = _inject_citation_links(full_reply, citations) if citations else full_reply
+        # Validation has had the full streaming duration to complete.
+        # Only inject links for URLs that are still live.
+        valid_web = await validation_task
+        valid_urls = {r["url"] for r in curated + valid_web}
+        valid_citations = [c for c in citations if c["url"] in valid_urls]
+
+        stored_reply = _inject_citation_links(full_reply, valid_citations) if valid_citations else full_reply
         _schedule_exchange_save(request.app.state.messages, user, conv_id, req.message, [stored_reply])
 
         yield _sse({"type": "done", "conversation_id": conv_id})

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -90,6 +90,17 @@ def _save_message(
     except Exception:
         pass
 
+
+def _save_exchange(col, user: UserPublic, conv_id: str, user_message: str, assistant_reply: list) -> None:
+    """Save a completed user/assistant exchange in order.
+
+    Always saves the user message first so its created_at timestamp is strictly
+    earlier than the assistant message. Called only after streaming completes
+    successfully, so a failed stream leaves no partial records in the DB.
+    """
+    _save_message(col, "user", user, conv_id, user_message)
+    _save_message(col, "assistant", user, conv_id, assistant_reply)
+
 def _build_system_instruction(answer_incorrectly: bool, has_choices: bool) -> str:
     if answer_incorrectly and has_choices:
         return (
@@ -205,6 +216,13 @@ async def _standard_stream(
     agent_tag: if set, each token SSE includes an "agent" field (used by double quiz).
     reply_prefix: prepended to the stored reply (e.g. "[AGENT A] " for double quiz).
     """
+    # Save the user message first so its created_at timestamp is always earlier
+    # than the assistant message saved after streaming. If both were saved
+    # concurrently after streaming, the assistant could receive an earlier
+    # timestamp (race condition), causing get_last_exchange to pair the wrong
+    # user message with the assistant reply on the next turn.
+    asyncio.create_task(asyncio.to_thread(_save_message, col, "user", user, conv_id, user_message))
+
     full_reply = ""
     async for is_error, delta, sse in _stream_agent_tokens(messages, agent_tag=agent_tag):
         yield sse
@@ -213,7 +231,6 @@ async def _standard_stream(
         full_reply += delta
 
     stored_reply = f"{reply_prefix}{full_reply}" if reply_prefix else full_reply
-    asyncio.create_task(asyncio.to_thread(_save_message, col, "user", user, conv_id, user_message))
     asyncio.create_task(asyncio.to_thread(_save_message, col, "assistant", user, conv_id, [stored_reply]))
     yield _sse({"type": "done", "conversation_id": conv_id})
 
@@ -325,7 +342,9 @@ async def double_chat(
             replies[tag] += delta
 
         replies_to_store = [f"[AGENT A] {replies['A']}", f"[AGENT B] {replies['B']}"]
-        asyncio.create_task(asyncio.to_thread(_save_message, col, "user", user, conv_id, req.message))
+        # User message is saved before assistant to ensure correct timestamp ordering
+        # (see _standard_stream for full explanation of the race condition).
+        await asyncio.to_thread(_save_message, col, "user", user, conv_id, req.message)
         asyncio.create_task(asyncio.to_thread(_save_message, col, "assistant", user, conv_id, replies_to_store))
         yield _sse({"type": "done", "conversation_id": conv_id})
 
@@ -376,21 +395,8 @@ async def chat_with_embedded_links(
     system_instruction = (
         _BASE_SYSTEM_PROMPT +
         " Use web searches to gather information and cite sources inline."
-        "Prioritize academic and institutional sources; avoid blog posts, news articles, or unverifiable sources."
-        "Prefer sources with stable, long-lived URLs."
-
-        "Preferred sources:"
-        "- Wikipedia (en.wikipedia.org)"
-        "- Encyclopaedia Britannica (britannica.com)"
-        "- Government sites (.gov such as CDC, NIH, NASA, NIST)"
-        "- University and educational sites (.edu)"
-        "- MIT OpenCourseWare (ocw.mit.edu)"
-        "- PubMed / NCBI (ncbi.nlm.nih.gov) for biomedical topics"
-        "- arXiv (arxiv.org) for physics, mathematics, and computer science preprints"
-        "- Wolfram MathWorld (mathworld.wolfram.com) for mathematics"
-        "- Stanford Encyclopedia of Philosophy (plato.stanford.edu) for philosophy"
-        "- IEEE Xplore (ieeexplore.ieee.org) for engineering and computer science"
-        "- ACM Digital Library (dl.acm.org) for computer science research"
+        " Prioritize academic and institutional sources; avoid blog posts, news articles, or unverifiable sources."
+        " Prefer sources with stable, long-lived URLs."
     )
 
     async def generate() -> AsyncGenerator[str, None]:
@@ -399,6 +405,7 @@ async def chat_with_embedded_links(
                 client=_client,
                 model=os.getenv("UF_OPENAI_API_MODEL"),
                 messages=_build_standard_messages(history, req.message, system_prompt=system_instruction),
+                db_links=getattr(request.app.state, "knowledge_links", []),
             )
         except Exception as e:
             yield _sse({"type": "error", "detail": f"Upstream AI request failed: {e}"})
@@ -406,13 +413,15 @@ async def chat_with_embedded_links(
 
         reply = output["reply"]
 
+        # Save user message before streaming so its timestamp is always earlier
+        # than the assistant message saved after (same race condition as _standard_stream).
+        _user_save_task = asyncio.create_task(asyncio.to_thread(_save_message, request.app.state.messages, "user", user, conv_id, req.message))
+
         # Stream the citation-injected reply word-by-word
         words = reply.split(" ")
         for i, word in enumerate(words):
             yield _sse({"type": "token", "content": word + ("" if i == len(words) - 1 else " ")})
 
-        # OPTIMIZATION: Non-blocking database saves (fire-and-forget)
-        asyncio.create_task(asyncio.to_thread(_save_message, request.app.state.messages, "user", user, conv_id, req.message))
         asyncio.create_task(asyncio.to_thread(_save_message, request.app.state.messages, "assistant", user, conv_id, [reply]))
         
         yield _sse({"type": "done", "conversation_id": conv_id})

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -91,15 +91,24 @@ def _save_message(
         pass
 
 
-def _save_exchange(col, user: UserPublic, conv_id: str, user_message: str, assistant_reply: list) -> None:
-    """Save a completed user/assistant exchange in order.
+_background_tasks: set = set()
 
-    Always saves the user message first so its created_at timestamp is strictly
-    earlier than the assistant message. Called only after streaming completes
-    successfully, so a failed stream leaves no partial records in the DB.
+
+def _schedule_exchange_save(col, user: UserPublic, conv_id: str, user_message: str, assistant_reply: list) -> None:
+    """Fire-and-forget: save user then assistant message in a background thread.
+
+    Saves user message first so its timestamp is strictly earlier than the
+    assistant message. Called only after streaming completes successfully, so a
+    failed stream leaves no partial records in the DB. Holds a strong reference
+    to the task until it completes to prevent early GC by the event loop.
     """
-    _save_message(col, "user", user, conv_id, user_message)
-    _save_message(col, "assistant", user, conv_id, assistant_reply)
+    def _save() -> None:
+        _save_message(col, "user", user, conv_id, user_message)
+        _save_message(col, "assistant", user, conv_id, assistant_reply)
+
+    task = asyncio.create_task(asyncio.to_thread(_save))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
 
 def _build_system_instruction(answer_incorrectly: bool, has_choices: bool) -> str:
     if answer_incorrectly and has_choices:
@@ -224,7 +233,7 @@ async def _standard_stream(
         full_reply += delta
 
     stored_reply = f"{reply_prefix}{full_reply}" if reply_prefix else full_reply
-    asyncio.create_task(asyncio.to_thread(_save_exchange, col, user, conv_id, user_message, [stored_reply]))
+    _schedule_exchange_save(col, user, conv_id, user_message, [stored_reply])
     yield _sse({"type": "done", "conversation_id": conv_id})
 
     if after_done and not (request and await request.is_disconnected()):
@@ -335,7 +344,7 @@ async def double_chat(
             replies[tag] += delta
 
         replies_to_store = [f"[AGENT A] {replies['A']}", f"[AGENT B] {replies['B']}"]
-        asyncio.create_task(asyncio.to_thread(_save_exchange, col, user, conv_id, req.message, replies_to_store))
+        _schedule_exchange_save(col, user, conv_id, req.message, replies_to_store)
         yield _sse({"type": "done", "conversation_id": conv_id})
 
     return StreamingResponse(generate(), media_type="text/event-stream", headers=_SSE_HEADERS)
@@ -397,7 +406,7 @@ async def chat_with_embedded_links(
             yield _sse({"type": "error", "detail": f"Search failed: {e}"})
             return
 
-        # Send citation map before tokens so frontend has it ready for injection
+        # Send validated citation map before tokens so frontend has it ready
         if citations:
             yield _sse({"type": "citations", "citations": citations})
 
@@ -411,9 +420,7 @@ async def chat_with_embedded_links(
 
         # Inject citations into the stored copy so history loads with working links
         stored_reply = _inject_citation_links(full_reply, citations) if citations else full_reply
-        asyncio.create_task(asyncio.to_thread(
-            _save_exchange, request.app.state.messages, user, conv_id, req.message, [stored_reply]
-        ))
+        _schedule_exchange_save(request.app.state.messages, user, conv_id, req.message, [stored_reply])
 
         yield _sse({"type": "done", "conversation_id": conv_id})
 

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -18,7 +18,7 @@ from ..schemas.chat import (
 )
 from .auth import get_current_user
 from ..services.chat import get_last_exchange, get_conversation_history as fetch_conversation_history
-from ..services.search import get_chat_response_with_search
+from ..services.search import prepare_search_messages, _inject_citation_links
 from ..services.followup import generate_followup_questions
 
 router = APIRouter()
@@ -366,8 +366,8 @@ async def followup_quiz_chat(
     )
 
 
-# Returns chat with inline citation links embedded in the response text.
-# Waits for search + generation + citation injection, then streams the reply word-by-word.
+# Streams tokens in real-time. Sends a citations SSE event before tokens so the
+# frontend can inject [phrase][N] markers into real links once the stream is done.
 @router.post("/chat/links")
 async def chat_with_embedded_links(
     req: ChatRequest,
@@ -378,8 +378,6 @@ async def chat_with_embedded_links(
         raise HTTPException(status_code=500, detail="Backend missing UF_OPENAI_API_KEY")
 
     conv_id = req.conversation_id or str(uuid.uuid4())
-    
-    # OPTIMIZATION: Non-blocking DB read for history
     history = await asyncio.to_thread(get_last_exchange, request.app.state.messages, conv_id)
 
     system_instruction = (
@@ -391,25 +389,32 @@ async def chat_with_embedded_links(
 
     async def generate() -> AsyncGenerator[str, None]:
         try:
-            output = await get_chat_response_with_search(
-                client=_client,
-                model=os.getenv("UF_OPENAI_API_MODEL"),
+            augmented_messages, citations = await prepare_search_messages(
                 messages=_build_standard_messages(history, req.message, system_prompt=system_instruction),
                 db_links=getattr(request.app.state, "knowledge_links", []),
             )
         except Exception as e:
-            yield _sse({"type": "error", "detail": f"Upstream AI request failed: {e}"})
+            yield _sse({"type": "error", "detail": f"Search failed: {e}"})
             return
 
-        reply = output["reply"]
+        # Send citation map before tokens so frontend has it ready for injection
+        if citations:
+            yield _sse({"type": "citations", "citations": citations})
 
-        # Stream the citation-injected reply word-by-word
-        words = reply.split(" ")
-        for i, word in enumerate(words):
-            yield _sse({"type": "token", "content": word + ("" if i == len(words) - 1 else " ")})
+        # Real token streaming
+        full_reply = ""
+        async for is_error, delta, sse in _stream_agent_tokens(augmented_messages):
+            yield sse
+            if is_error:
+                return
+            full_reply += delta
 
-        asyncio.create_task(asyncio.to_thread(_save_exchange, request.app.state.messages, user, conv_id, req.message, [reply]))
-        
+        # Inject citations into the stored copy so history loads with working links
+        stored_reply = _inject_citation_links(full_reply, citations) if citations else full_reply
+        asyncio.create_task(asyncio.to_thread(
+            _save_exchange, request.app.state.messages, user, conv_id, req.message, [stored_reply]
+        ))
+
         yield _sse({"type": "done", "conversation_id": conv_id})
 
     return StreamingResponse(generate(), media_type="text/event-stream", headers=_SSE_HEADERS)

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -393,8 +393,8 @@ async def chat_with_embedded_links(
     system_instruction = (
         _BASE_SYSTEM_PROMPT +
         " Use web searches to gather information and cite sources inline."
-        " Prioritize academic and institutional sources; avoid blog posts, news articles, or unverifiable sources."
-        " Prefer sources with stable, long-lived URLs."
+        #" Prioritize academic and institutional sources; avoid blog posts, news articles, or unverifiable sources."
+        #" Prefer sources with stable, long-lived URLs."
     )
 
     async def generate() -> AsyncGenerator[str, None]:
@@ -436,7 +436,7 @@ async def chat_with_embedded_links(
         stored_reply = _inject_citation_links(full_reply, citations) if citations else full_reply
         _schedule_exchange_save(request.app.state.messages, user, conv_id, req.message, [stored_reply])
 
-        yield _sse({"type": "done", "conversation_id": conv_id})
+        yield _sse({"type": "done", "conversation_id": conv_id, "reply": stored_reply})
 
     return StreamingResponse(generate(), media_type="text/event-stream", headers=_SSE_HEADERS)
 

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -216,13 +216,6 @@ async def _standard_stream(
     agent_tag: if set, each token SSE includes an "agent" field (used by double quiz).
     reply_prefix: prepended to the stored reply (e.g. "[AGENT A] " for double quiz).
     """
-    # Save the user message first so its created_at timestamp is always earlier
-    # than the assistant message saved after streaming. If both were saved
-    # concurrently after streaming, the assistant could receive an earlier
-    # timestamp (race condition), causing get_last_exchange to pair the wrong
-    # user message with the assistant reply on the next turn.
-    asyncio.create_task(asyncio.to_thread(_save_message, col, "user", user, conv_id, user_message))
-
     full_reply = ""
     async for is_error, delta, sse in _stream_agent_tokens(messages, agent_tag=agent_tag):
         yield sse
@@ -231,7 +224,7 @@ async def _standard_stream(
         full_reply += delta
 
     stored_reply = f"{reply_prefix}{full_reply}" if reply_prefix else full_reply
-    asyncio.create_task(asyncio.to_thread(_save_message, col, "assistant", user, conv_id, [stored_reply]))
+    asyncio.create_task(asyncio.to_thread(_save_exchange, col, user, conv_id, user_message, [stored_reply]))
     yield _sse({"type": "done", "conversation_id": conv_id})
 
     if after_done and not (request and await request.is_disconnected()):
@@ -342,10 +335,7 @@ async def double_chat(
             replies[tag] += delta
 
         replies_to_store = [f"[AGENT A] {replies['A']}", f"[AGENT B] {replies['B']}"]
-        # User message is saved before assistant to ensure correct timestamp ordering
-        # (see _standard_stream for full explanation of the race condition).
-        await asyncio.to_thread(_save_message, col, "user", user, conv_id, req.message)
-        asyncio.create_task(asyncio.to_thread(_save_message, col, "assistant", user, conv_id, replies_to_store))
+        asyncio.create_task(asyncio.to_thread(_save_exchange, col, user, conv_id, req.message, replies_to_store))
         yield _sse({"type": "done", "conversation_id": conv_id})
 
     return StreamingResponse(generate(), media_type="text/event-stream", headers=_SSE_HEADERS)
@@ -413,16 +403,12 @@ async def chat_with_embedded_links(
 
         reply = output["reply"]
 
-        # Save user message before streaming so its timestamp is always earlier
-        # than the assistant message saved after (same race condition as _standard_stream).
-        _user_save_task = asyncio.create_task(asyncio.to_thread(_save_message, request.app.state.messages, "user", user, conv_id, req.message))
-
         # Stream the citation-injected reply word-by-word
         words = reply.split(" ")
         for i, word in enumerate(words):
             yield _sse({"type": "token", "content": word + ("" if i == len(words) - 1 else " ")})
 
-        asyncio.create_task(asyncio.to_thread(_save_message, request.app.state.messages, "assistant", user, conv_id, [reply]))
+        asyncio.create_task(asyncio.to_thread(_save_exchange, request.app.state.messages, user, conv_id, req.message, [reply]))
         
         yield _sse({"type": "done", "conversation_id": conv_id})
 

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -18,7 +18,8 @@ from ..schemas.chat import (
 )
 from .auth import get_current_user
 from ..services.chat import get_last_exchange, get_conversation_history as fetch_conversation_history
-from ..services.search import _run_search, _filter_valid_urls, _build_search_context, _inject_citation_links
+from ..services.search import _build_search_context, _inject_citation_links
+# from ..services.search import _run_search, _filter_valid_urls  # external search disabled
 from ..services.followup import generate_followup_questions
 
 router = APIRouter()
@@ -397,12 +398,13 @@ async def chat_with_embedded_links(
     )
 
     async def generate() -> AsyncGenerator[str, None]:
-        # Run search first — results are needed to build AI context
-        try:
-            raw_web = await _run_search(req.message)
-        except Exception as e:
-            yield _sse({"type": "error", "detail": f"Search failed: {e}"})
-            return
+        # External web search disabled — citations come from DB links only.
+        # To re-enable: uncomment _run_search/_filter_valid_urls imports and restore lines below.
+        # try:
+        #     raw_web = await _run_search(req.message)
+        # except Exception as e:
+        #     yield _sse({"type": "error", "detail": f"Search failed: {e}"})
+        #     return
 
         curated = [
             {"title": l.get("title", ""), "url": l.get("url", ""), "snippet": l.get("description", "")}
@@ -411,13 +413,10 @@ async def chat_with_embedded_links(
         ]
         augmented_messages, citations = _build_search_context(
             _build_standard_messages(history, req.message, system_prompt=system_instruction),
-            curated + raw_web,
+            curated,  # was: curated + raw_web
         )
 
-        # Kick off URL validation as a background task so it runs while tokens stream.
-        # The AI already has all results as context; validation only affects which
-        # citation links get injected into the stored reply at the end.
-        validation_task = asyncio.create_task(_filter_valid_urls(raw_web))
+        # validation_task = asyncio.create_task(_filter_valid_urls(raw_web))  # disabled with search
 
         if citations:
             yield _sse({"type": "citations", "citations": citations})
@@ -426,17 +425,15 @@ async def chat_with_embedded_links(
         async for is_error, delta, sse in _stream_agent_tokens(augmented_messages):
             yield sse
             if is_error:
-                validation_task.cancel()
+                # validation_task.cancel()  # disabled with search
                 return
             full_reply += delta
 
-        # Validation has had the full streaming duration to complete.
-        # Only inject links for URLs that are still live.
-        valid_web = await validation_task
-        valid_urls = {r["url"] for r in curated + valid_web}
-        valid_citations = [c for c in citations if c["url"] in valid_urls]
+        # valid_web = await validation_task        # disabled with search
+        # valid_urls = {r["url"] for r in curated + valid_web}  # disabled with search
+        # valid_citations = [c for c in citations if c["url"] in valid_urls]  # disabled with search
 
-        stored_reply = _inject_citation_links(full_reply, valid_citations) if valid_citations else full_reply
+        stored_reply = _inject_citation_links(full_reply, citations) if citations else full_reply
         _schedule_exchange_save(request.app.state.messages, user, conv_id, req.message, [stored_reply])
 
         yield _sse({"type": "done", "conversation_id": conv_id})

--- a/backend/app/api/knowledge_links.py
+++ b/backend/app/api/knowledge_links.py
@@ -41,7 +41,15 @@ def create_new_knowledge_link(
 ):
     links = get_knowledge_links_collection(request.app.state.db)
     ensure_indexes(links)
-    return create_knowledge_link(links, data)
+    created = create_knowledge_link(links, data)
+    if created.active:
+        request.app.state.knowledge_links.append({
+            "id": created.id,
+            "title": created.title,
+            "url": str(created.url),
+            "description": created.description,
+        })
+    return created
 
 @router.put("/{link_id}", response_model=KnowledgeLinkPublic)
 def update_existing_knowledge_link(
@@ -57,6 +65,16 @@ def update_existing_knowledge_link(
     if not updated:
         raise HTTPException(status_code=404, detail="Knowledge link not found")
 
+    request.app.state.knowledge_links = [
+        l for l in request.app.state.knowledge_links if l["id"] != link_id
+    ]
+    if updated.active:
+        request.app.state.knowledge_links.append({
+            "id": updated.id,
+            "title": updated.title,
+            "url": str(updated.url),
+            "description": updated.description,
+        })
     return updated
 
 @router.delete("/{link_id}", response_model=KnowledgeLinkPublic)
@@ -72,4 +90,7 @@ def delete_existing_knowledge_link(
     if not deleted:
         raise HTTPException(status_code=404, detail="Knowledge link not found")
 
+    request.app.state.knowledge_links = [
+        l for l in request.app.state.knowledge_links if l["id"] != link_id
+    ]
     return deleted

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,7 +9,7 @@ class Settings:
     # JWT / Auth
     JWT_SECRET: str = os.getenv("JWT_SECRET", "dev-secret-change-me")
     JWT_ALG: str = os.getenv("JWT_ALG", "HS256")
-    JWT_EXPIRES_MIN: int = int(os.getenv("JWT_EXPIRES_MIN", "60"))  # 60 minutes
+    JWT_EXPIRES_MIN: int = int(os.getenv("JWT_EXPIRES_MIN", "180"))  # 3 hours
 
     COOKIE_NAME: str = os.getenv("COOKIE_NAME", "session")
     COOKIE_SECURE: bool = os.getenv("COOKIE_SECURE", "").lower() in {"1","true","yes"}  # True in prod

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -54,9 +54,17 @@ def _startup():
         from .services.surveys import ensure_survey_indexes
         ensure_survey_indexes(db)
 
+        from .services.knowledge_links import get_knowledge_links_collection, ensure_indexes as ensure_links_indexes
+        links_col = get_knowledge_links_collection(db)
+        ensure_links_indexes(links_col)
+
         app.state.mongo_client = client
         app.state.db = db
         app.state.messages = messages
+        app.state.knowledge_links = [
+            {"id": str(doc["_id"]), "title": doc["title"], "url": doc["url"], "description": doc["description"]}
+            for doc in links_col.find({"active": True})
+        ]
 
     except ServerSelectionTimeoutError as e:
         # Optional: log & re-raise to crash on bad config in prod

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -14,18 +14,24 @@ async def _run_search(query: str, max_results: int = 5) -> list[dict]:
     """Execute a NaviGator AI search asynchronously and return raw results.
 
     Returns [] on any failure so the caller can fall back to answering without search.
+    Sub-page URLs (e.g. khanacademy.com/page) are returned as-is from the search API
+    — this function does not restrict results to root domains.
     """
     try:
-        # Use AsyncClient to prevent blocking the FastAPI event loop
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(
                 f"{_UF_BASE_URL}/v1/search/{_UF_SEARCH_TOOL}",
                 headers={"Authorization": f"Bearer {_UF_API_KEY}", "Content-Type": "application/json"},
                 json={"query": query, "max_results": max_results},
             )
+            if not resp.is_success:
+                print(f"[search] _run_search HTTP {resp.status_code} body: {resp.text[:500]}")
             resp.raise_for_status()
-            return resp.json().get("results", [])
-    except Exception:
+            results = resp.json().get("results", [])
+            print(f"[search] _run_search: query={query!r} returned {len(results)} result(s)")
+            return results
+    except Exception as e:
+        print(f"[search] _run_search failed: {type(e).__name__}: {e}")
         return []
 
 
@@ -36,9 +42,11 @@ async def _check_url(url: str, client: httpx.AsyncClient) -> tuple[str, bool]:
     - HTTP 404 status
     - Redirected to the site homepage (path vanished)
     Keeps the URL on any other response or error.
+
+    Sub-page URLs (e.g. khanacademy.com/algebra) are kept as long as they do not
+    redirect to the root domain — this preserves specific resource pages.
     """
     try:
-        # Stream the GET request asynchronously (no body downloaded)
         async with client.stream(
             "GET", url,
             follow_redirects=True,
@@ -46,8 +54,9 @@ async def _check_url(url: str, client: httpx.AsyncClient) -> tuple[str, bool]:
         ) as r:
             if r.status_code == 404:
                 return url, False
-            
-            # Homepage redirect check
+
+            # Drop URLs that redirect from a specific path to the site root —
+            # this means the specific page no longer exists.
             original_path = urlparse(url).path.rstrip("/")
             final_path = urlparse(str(r.url)).path.rstrip("/")
             if original_path and not final_path:
@@ -58,46 +67,40 @@ async def _check_url(url: str, client: httpx.AsyncClient) -> tuple[str, bool]:
 
 
 async def _filter_valid_urls(results: list[dict]) -> list[dict]:
-    """Remove results whose URL definitively returns 404. Checks run concurrently via asyncio."""
+    """Remove results whose URL definitively returns 404 or redirects to a homepage.
+
+    Runs checks concurrently (15s client timeout) so even slow URLs are validated
+    without serialising the wait. Intended to run as a background asyncio.Task
+    concurrent with token streaming so the full 15s is never felt as blocking latency.
+    """
     if not results:
         return results
 
-    # Share a single AsyncClient for all concurrent checks to save connection overhead
-    async with httpx.AsyncClient(timeout=3.0, headers={"User-Agent": "Mozilla/5.0"}) as client:
-        # Create a list of background tasks for checking URLs
+    async with httpx.AsyncClient(timeout=15.0, headers={"User-Agent": "Mozilla/5.0"}) as client:
         tasks = [_check_url(r["url"], client) for r in results]
-        
-        # Await them all simultaneously
         checked_urls = await asyncio.gather(*tasks)
 
-    # Filter into a set of valid URLs
     valid_urls = {url for url, is_valid in checked_urls if is_valid}
-    return [r for r in results if r["url"] in valid_urls]
+    filtered = [r for r in results if r["url"] in valid_urls]
+    dropped = len(results) - len(filtered)
+    if dropped:
+        print(f"[search] _filter_valid_urls: dropped {dropped} of {len(results)} URL(s)")
+    return filtered
 
 
-async def prepare_search_messages(
+def _build_search_context(
     messages: list[dict],
-    db_links: list[dict] | None = None,
+    results: list[dict],
 ) -> tuple[list[dict], list[dict]]:
-    """Run search, build augmented message list, return (augmented_messages, citations).
+    """Build the augmented message list and citation map from assembled results.
 
+    Pure function — no I/O. Accepts an already-assembled result list so callers
+    can control validation independently (e.g. run it as a background task concurrent
+    with token streaming).
+
+    Returns (augmented_messages, citations) or (messages, []) if results is empty.
     citations format: [{"n": int, "title": str, "url": str}]
-    Returns (original messages, []) if search yields no results — caller should
-    fall back to a plain LLM call in that case.
     """
-    query = next(
-        (m["content"] for m in reversed(messages) if m["role"] == "user"), ""
-    )
-
-    results = await _run_search(query)
-    results = await _filter_valid_urls(results)
-
-    curated = [
-        {"title": l["title"], "url": l["url"], "snippet": l["description"]}
-        for l in (db_links or [])
-    ]
-    results = curated + results
-
     if not results:
         return messages, []
 
@@ -112,7 +115,7 @@ async def prepare_search_messages(
 
     citation_instruction = (
         NL + NL
-        + "Cite sources by wrapping the key phrase that supports each fact in a reference-style link: "
+        + "Cite sources by wrapping the first phrase that supports each fact in a reference-style link: "
         "[key phrase][N] where N is the source number. "
         "Place it immediately around the words the source supports. "
         "Example: 'Mitosis involves [four distinct phases][1] and requires [spindle fibers][2].' "
@@ -164,6 +167,31 @@ def _inject_citation_links(text: str, citations: list[dict]) -> str:
         # Fallback: bare [N] → [N](url)
         text = re.sub(r"\[" + n + r"\](?!\()", f"[{n}]({url})", text)
     return text
+
+
+async def prepare_search_messages(
+    messages: list[dict],
+    db_links: list[dict] | None = None,
+) -> tuple[list[dict], list[dict]]:
+    """Run search + URL validation, build augmented message list, return (augmented_messages, citations).
+
+    Convenience wrapper used by get_chat_response_with_search. For streaming endpoints
+    that need URL validation to run concurrently with token output, use _run_search,
+    _filter_valid_urls, and _build_search_context directly.
+    """
+    query = next(
+        (m["content"] for m in reversed(messages) if m["role"] == "user"), ""
+    )
+
+    raw_web = await _run_search(query)
+    valid_web = await _filter_valid_urls(raw_web)
+
+    curated = [
+        {"title": l.get("title", ""), "url": l.get("url", ""), "snippet": l.get("description", "")}
+        for l in (db_links or [])
+        if l.get("url")
+    ]
+    return _build_search_context(messages, curated + valid_web)
 
 
 async def get_chat_response_with_search(

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -75,6 +75,73 @@ async def _filter_valid_urls(results: list[dict]) -> list[dict]:
     return [r for r in results if r["url"] in valid_urls]
 
 
+async def prepare_search_messages(
+    messages: list[dict],
+    db_links: list[dict] | None = None,
+) -> tuple[list[dict], list[dict]]:
+    """Run search, build augmented message list, return (augmented_messages, citations).
+
+    citations format: [{"n": int, "title": str, "url": str}]
+    Returns (original messages, []) if search yields no results — caller should
+    fall back to a plain LLM call in that case.
+    """
+    query = next(
+        (m["content"] for m in reversed(messages) if m["role"] == "user"), ""
+    )
+
+    results = await _run_search(query)
+    results = await _filter_valid_urls(results)
+
+    curated = [
+        {"title": l["title"], "url": l["url"], "snippet": l["description"]}
+        for l in (db_links or [])
+    ]
+    results = curated + results
+
+    if not results:
+        return messages, []
+
+    NL = chr(10)
+    context_lines = []
+    for i, r in enumerate(results):
+        context_lines.append("[" + str(i + 1) + "] " + r["title"])
+        context_lines.append("URL: " + r["url"])
+        context_lines.append(r["snippet"])
+        context_lines.append("")
+    search_context = NL.join(context_lines)
+
+    citation_instruction = (
+        NL + NL
+        + "Cite sources by wrapping the key phrase that supports each fact in a reference-style link: "
+        "[key phrase][N] where N is the source number. "
+        "Place it immediately around the words the source supports. "
+        "Example: 'Mitosis involves [four distinct phases][1] and requires [spindle fibers][2].' "
+        "Do not write out URLs, do not add a References or Sources section, "
+        "do not add a citations list at the end under any circumstances."
+    )
+
+    system = next((m for m in messages if m["role"] == "system"), None)
+    if system:
+        patched = [
+            {**system, "content": system["content"] + citation_instruction},
+            *[m for m in messages if m["role"] != "system"],
+        ]
+    else:
+        patched = [{"role": "system", "content": citation_instruction.strip()}, *messages]
+
+    augmented = list(patched)
+    last_user_idx = next(
+        i for i in reversed(range(len(augmented))) if augmented[i]["role"] == "user"
+    )
+    augmented[last_user_idx] = {
+        **augmented[last_user_idx],
+        "content": augmented[last_user_idx]["content"] + NL + NL + "Search results:" + NL + search_context,
+    }
+
+    citations = [{"n": i + 1, "title": r["title"], "url": r["url"]} for i, r in enumerate(results)]
+    return augmented, citations
+
+
 def _inject_citation_links(text: str, citations: list[dict]) -> str:
     """Replace citation markers in the model's reply with markdown links.
 
@@ -111,76 +178,14 @@ async def get_chat_response_with_search(
     Returns:
         {"reply": str, "citations": list[{"n": int, "title": str, "url": str}]}
     """
-    query = next(
-        (m["content"] for m in reversed(messages) if m["role"] == "user"), ""
-    )
+    augmented, citations = await prepare_search_messages(messages, db_links)
 
-    # Await the new async functions
-    results = await _run_search(query)
-    results = await _filter_valid_urls(results)
-
-    curated = [
-        {"title": l["title"], "url": l["url"], "snippet": l["description"]}
-        for l in (db_links or [])
-    ]
-    results = curated + results
-
-    if not results:
-        resp = await client.chat.completions.create(model=model, messages=messages)
+    if not citations:
+        resp = await client.chat.completions.create(model=model, messages=augmented)
         return {"reply": (resp.choices[0].message.content or "").strip(), "citations": []}
-
-    NL = chr(10)
-
-    context_lines = []
-    for i, r in enumerate(results):
-        context_lines.append("[" + str(i + 1) + "] " + r["title"])
-        context_lines.append("URL: " + r["url"])
-        context_lines.append(r["snippet"])
-        context_lines.append("")
-    search_context = NL.join(context_lines)
-
-    citation_instruction = (
-        NL + NL
-        + "Cite sources by wrapping the key phrase that supports each fact in a reference-style link: "
-        "[key phrase][N] where N is the source number. "
-        "Place it immediately around the words the source supports. "
-        "Example: 'Mitosis involves [four distinct phases][1] and requires [spindle fibers][2].' "
-        "Do not write out URLs, do not add a References or Sources section."
-    )
-
-    system = next((m for m in messages if m["role"] == "system"), None)
-    if system:
-        patched_messages = [
-            {**system, "content": system["content"] + citation_instruction},
-            *[m for m in messages if m["role"] != "system"],
-        ]
-    else:
-        patched_messages = [
-            {"role": "system", "content": citation_instruction.strip()},
-            *messages,
-        ]
-
-    augmented = list(patched_messages)
-    last_user_idx = next(
-        i for i in reversed(range(len(augmented))) if augmented[i]["role"] == "user"
-    )
-    augmented[last_user_idx] = {
-        **augmented[last_user_idx],
-        "content": (
-            augmented[last_user_idx]["content"]
-            + NL + NL + "Search results:" + NL
-            + search_context
-        ),
-    }
 
     resp = await client.chat.completions.create(model=model, messages=augmented)
     reply_text = (resp.choices[0].message.content or "").strip()
-
-    citations = [
-        {"n": i + 1, "title": r["title"], "url": r["url"]}
-        for i, r in enumerate(results)
-    ]
-
     reply_text = _inject_citation_links(reply_text, citations)
 
     return {"reply": reply_text, "citations": citations}

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -7,22 +7,28 @@ from openai import AsyncOpenAI
 
 _UF_BASE_URL = os.getenv("UF_OPENAI_BASE_URL", "https://api.ai.it.ufl.edu")
 _UF_API_KEY = os.getenv("UF_OPENAI_API_KEY")
-_UF_SEARCH_TOOL = os.getenv("UF_SEARCH_TOOL_NAME", "litellm-search")
+_UF_SEARCH_TOOL = os.getenv("UF_SEARCH_TOOL_NAME", "")
 
 
 async def _run_search(query: str, max_results: int = 5) -> list[dict]:
     """Execute a NaviGator AI search asynchronously and return raw results.
 
     Returns [] on any failure so the caller can fall back to answering without search.
-    Sub-page URLs (e.g. khanacademy.com/page) are returned as-is from the search API
-    — this function does not restrict results to root domains.
+    If UF_SEARCH_TOOL_NAME is set, passes it in the URL path. Otherwise falls back
+    to passing the chat model name as the 'model' body parameter.
     """
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
+            body: dict = {"query": query, "max_results": max_results}
+            if _UF_SEARCH_TOOL:
+                url = f"{_UF_BASE_URL}/v1/search/{_UF_SEARCH_TOOL}"
+            else:
+                url = f"{_UF_BASE_URL}/v1/search"
+                body["model"] = os.getenv("UF_OPENAI_API_MODEL", "")
             resp = await client.post(
-                f"{_UF_BASE_URL}/v1/search/{_UF_SEARCH_TOOL}",
+                url,
                 headers={"Authorization": f"Bearer {_UF_API_KEY}", "Content-Type": "application/json"},
-                json={"query": query, "max_results": max_results},
+                json=body,
             )
             if not resp.is_success:
                 print(f"[search] _run_search HTTP {resp.status_code} body: {resp.text[:500]}")
@@ -42,9 +48,6 @@ async def _check_url(url: str, client: httpx.AsyncClient) -> tuple[str, bool]:
     - HTTP 404 status
     - Redirected to the site homepage (path vanished)
     Keeps the URL on any other response or error.
-
-    Sub-page URLs (e.g. khanacademy.com/algebra) are kept as long as they do not
-    redirect to the root domain — this preserves specific resource pages.
     """
     try:
         async with client.stream(
@@ -69,9 +72,8 @@ async def _check_url(url: str, client: httpx.AsyncClient) -> tuple[str, bool]:
 async def _filter_valid_urls(results: list[dict]) -> list[dict]:
     """Remove results whose URL definitively returns 404 or redirects to a homepage.
 
-    Runs checks concurrently (15s client timeout) so even slow URLs are validated
-    without serialising the wait. Intended to run as a background asyncio.Task
-    concurrent with token streaming so the full 15s is never felt as blocking latency.
+    Runs checks concurrently so even slow URLs are validated without serialising
+    the wait. Intended to run as a background task concurrent with token streaming.
     """
     if not results:
         return results
@@ -94,11 +96,8 @@ def _build_search_context(
 ) -> tuple[list[dict], list[dict]]:
     """Build the augmented message list and citation map from assembled results.
 
-    Pure function — no I/O. Accepts an already-assembled result list so callers
-    can control validation independently (e.g. run it as a background task concurrent
-    with token streaming).
-
-    Returns (augmented_messages, citations) or (messages, []) if results is empty.
+    Pure function — no I/O. Returns (augmented_messages, citations) or
+    (messages, []) if results is empty.
     citations format: [{"n": int, "title": str, "url": str}]
     """
     if not results:
@@ -113,14 +112,38 @@ def _build_search_context(
         context_lines.append("")
     search_context = NL.join(context_lines)
 
+    # Alternative citation instruction (more detailed, kept for reference):
+    # citation_instruction = (
+    #     NL + NL
+    #     + "When you write a sentence that is supported by a search result, cite it by writing the "
+    #     "first key noun or short phrase (1–4 words) in that sentence as [phrase][N], "
+    #     "where N is the source number. Write the marker as you write the word — inline, not at the end. "
+    #     "Never append a citation after the sentence ends. Never use equations or formulas as the phrase. "
+    #     "Example: 'The [probability][1] of rolling a 6 is 1/6.' "
+    #     "Example: '[Mitosis][1] involves four distinct phases.' "
+    #     "Do not write out URLs. Do not add a references section or citations list."
+    #     "Write in-line citations for the first key noun or short phrase that matches the topic or content of the search result."
+    #     "Format the citation marker as [key phrase][N], where N corresponds to the numbered search result. Place the marker immediately after the key phrase, not at the end of the sentence. "
+    #     "Do not use equations or formulas as key phrases. "
+    #     "Do not add extra phrases just to fit in a citation. Use the closest word or phrase that exists naturally in the sentence. "
+    #     "Do not format the citations as footnotes."
+    #     "For example, when citing a search result about probability, key phrases to wrap might be 'probability', 'fair dice', 'outcomes', 'Baye's Theorem', 'addition rule', 'independent events,' etc."
+    #     "Another example: When citing a search result about mitosis, key phrases to wrap might be 'mitosis', 'cell division', 'prophase', 'metaphase', 'anaphase', 'telophase', etc. "
+    #     "Do not add a separate references section or list of citations at the end of your response. "
+    # )
     citation_instruction = (
         NL + NL
         + "Cite sources by wrapping the first phrase that supports each fact in a reference-style link: "
         "[key phrase][N] where N is the source number. "
-        "Place it immediately around the words the source supports. "
-        "Example: 'Mitosis involves [four distinct phases][1] and requires [spindle fibers][2].' "
+        "Place it immediately around the first words the source supports or that match the general topic that the sources cover. "
+        "Do not use equations or formulas as key phrases. "
+        "Do not add extra phrases just to fit in a citation. Use the closest word or phrase that exists naturally in the sentence. "
         "Do not write out URLs, do not add a References or Sources section, "
         "do not add a citations list at the end under any circumstances."
+        "Example: '[Mitosis][1] involves [four distinct phases][2] and requires [spindle fibers][3].' "
+        "Example: The [probability][1] of rolling a 6 on a [fair die][2] is 1/6. "
+        "Example: The [Eiffel Tower][1] is located in Paris. "
+        "Example: The [chemical decomposition of hydrogen peroxide][1] produces water and oxygen. "
     )
 
     system = next((m for m in messages if m["role"] == "system"), None)
@@ -145,39 +168,113 @@ def _build_search_context(
     return augmented, citations
 
 
+_STOP_WORDS = frozenset({
+    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "is", "are", "was", "be", "as", "it",
+    "its", "this", "that", "how", "what", "when", "where", "why", "which",
+    "about", "into", "than", "more", "also", "has", "have", "had",
+})
+
+_RE_UNLINKED_PREFIX = r"(?<!\[)(?<!\()\b"
+_RE_UNLINKED_SUFFIX = r"\b(?!\])"
+_RE_FORMULA_CHARS = re.compile(r"[=÷×≥≤≠→←+\-*/\\|^]")
+
+
+def _title_keywords(title: str) -> list[str]:
+    """Extract candidate keywords from a result title, longest first."""
+    words = re.split(r"[\s\-\u2013\u2014|:/,.()\[\]]+", title)
+    candidates = [w for w in words if len(w) >= 4 and w.lower() not in _STOP_WORDS]
+    return sorted(candidates, key=len, reverse=True)
+
+
+def _unlinked_search(term: str, text: str) -> re.Match | None:
+    """Find the first occurrence of term in text that is not already inside a markdown link."""
+    return re.search(
+        _RE_UNLINKED_PREFIX + re.escape(term) + _RE_UNLINKED_SUFFIX,
+        text, re.IGNORECASE,
+    )
+
+
+def _place_marker_inline(phrase: str, url: str, before_marker: str, after_marker: str) -> str:
+    """Try to place a citation link for phrase inside before_marker.
+
+    Tries the exact phrase first, then progressively shorter contiguous
+    sub-phrases (longest first, stop-words and short tokens skipped).
+    Falls back to in-place conversion if nothing matches.
+    """
+    if not _RE_FORMULA_CHARS.search(phrase):
+        exact = _unlinked_search(phrase, before_marker)
+        if exact:
+            word = before_marker[exact.start():exact.end()]
+            return before_marker[:exact.start()] + f"[{word}]({url})" + before_marker[exact.end():] + after_marker
+
+    words = phrase.split()
+    for length in range(len(words) - 1, 0, -1):
+        for start in range(len(words) - length + 1):
+            sub = " ".join(words[start:start + length])
+            if sub.lower() in _STOP_WORDS or len(sub) < 4 or _RE_FORMULA_CHARS.search(sub):
+                continue
+            sub_match = _unlinked_search(sub, before_marker)
+            if sub_match:
+                word = before_marker[sub_match.start():sub_match.end()]
+                return (
+                    before_marker[:sub_match.start()]
+                    + f"[{word}]({url})"
+                    + before_marker[sub_match.end():]
+                    + after_marker
+                )
+
+    return before_marker + f"[{phrase}]({url})" + after_marker
+
+
 def _inject_citation_links(text: str, citations: list[dict]) -> str:
     """Replace citation markers in the model's reply with markdown links.
 
-    Primary pattern:  [key phrase][N] → [key phrase](url)
-    Fallback pattern: [N]            → [N](url)
-
-    URLs are injected deterministically — the model never writes them directly,
-    so they cannot be hallucinated or mangled.
+    Strategy 1 — model used [phrase][N]:
+      Find the phrase before the marker; if found link it there and drop the
+      marker. If not found exactly, try shorter sub-phrases. Falls back to
+      converting the marker in place.
+    Strategy 2 — model used bare [N]: convert to [N](url).
+    Strategy 3 — no marker: keyword-match against the result title.
     """
     for c in citations:
         url = c["url"]
         n = str(c["n"])
-        # Primary: [key phrase][N] → [key phrase](url)
-        # \s* between the brackets tolerates any whitespace the model may insert
-        text = re.sub(
-            r"\[([^\]\[]+)\]\s*\[" + n + r"\]",
-            lambda m, u=url: f"[{m.group(1)}]({u})",
-            text,
-        )
-        # Fallback: bare [N] → [N](url)
-        text = re.sub(r"\[" + n + r"\](?!\()", f"[{n}]({url})", text)
+
+        marker_match = re.search(r"\[([^\]\[]+)\]\s*\[" + n + r"\]", text)
+        if marker_match:
+            text = _place_marker_inline(
+                marker_match.group(1), url,
+                text[:marker_match.start()],
+                text[marker_match.end():],
+            )
+            continue
+
+        new_text = re.sub(r"\[" + n + r"\](?!\()", f"[{n}]({url})", text)
+        if new_text != text:
+            text = new_text
+            continue
+
+        for kw in _title_keywords(c["title"]):
+            kw_match = _unlinked_search(kw, text)
+            if kw_match:
+                word = text[kw_match.start():kw_match.end()]
+                text = text[:kw_match.start()] + f"[{word}]({url})" + text[kw_match.end():]
+                break
+
     return text
 
 
-async def prepare_search_messages(
+async def get_chat_response_with_search(
+    client: AsyncOpenAI,
+    model: str,
     messages: list[dict],
     db_links: list[dict] | None = None,
-) -> tuple[list[dict], list[dict]]:
-    """Run search + URL validation, build augmented message list, return (augmented_messages, citations).
+) -> dict[str, str | list]:
+    """One-shot search: search, validate URLs, inject context, one LLM call.
 
-    Convenience wrapper used by get_chat_response_with_search. For streaming endpoints
-    that need URL validation to run concurrently with token output, use _run_search,
-    _filter_valid_urls, and _build_search_context directly.
+    Returns:
+        {"reply": str, "citations": list[{"n": int, "title": str, "url": str}]}
     """
     query = next(
         (m["content"] for m in reversed(messages) if m["role"] == "user"), ""
@@ -191,29 +288,10 @@ async def prepare_search_messages(
         for l in (db_links or [])
         if l.get("url")
     ]
-    return _build_search_context(messages, curated + valid_web)
-
-
-async def get_chat_response_with_search(
-    client: AsyncOpenAI,
-    model: str,
-    messages: list[dict],
-    db_links: list[dict] | None = None,
-) -> dict[str, str | list]:
-    """One-shot search: search once, validate URLs, inject results as context,
-    one LLM call, then replace citation markers with real URLs deterministically.
-
-    Returns:
-        {"reply": str, "citations": list[{"n": int, "title": str, "url": str}]}
-    """
-    augmented, citations = await prepare_search_messages(messages, db_links)
-
-    if not citations:
-        resp = await client.chat.completions.create(model=model, messages=augmented)
-        return {"reply": (resp.choices[0].message.content or "").strip(), "citations": []}
+    augmented, citations = _build_search_context(messages, curated + valid_web)
 
     resp = await client.chat.completions.create(model=model, messages=augmented)
     reply_text = (resp.choices[0].message.content or "").strip()
-    reply_text = _inject_citation_links(reply_text, citations)
+    reply_text = _inject_citation_links(reply_text, citations) if citations else reply_text
 
     return {"reply": reply_text, "citations": citations}

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -88,8 +88,9 @@ def _inject_citation_links(text: str, citations: list[dict]) -> str:
         url = c["url"]
         n = str(c["n"])
         # Primary: [key phrase][N] → [key phrase](url)
+        # \s* between the brackets tolerates any whitespace the model may insert
         text = re.sub(
-            r"\[([^\]\[]+)\]\[" + n + r"\]",
+            r"\[([^\]\[]+)\]\s*\[" + n + r"\]",
             lambda m, u=url: f"[{m.group(1)}]({u})",
             text,
         )
@@ -102,6 +103,7 @@ async def get_chat_response_with_search(
     client: AsyncOpenAI,
     model: str,
     messages: list[dict],
+    db_links: list[dict] | None = None,
 ) -> dict[str, str | list]:
     """One-shot search: search once, validate URLs, inject results as context,
     one LLM call, then replace citation markers with real URLs deterministically.
@@ -116,6 +118,12 @@ async def get_chat_response_with_search(
     # Await the new async functions
     results = await _run_search(query)
     results = await _filter_valid_urls(results)
+
+    curated = [
+        {"title": l["title"], "url": l["url"], "snippet": l["description"]}
+        for l in (db_links or [])
+    ]
+    results = curated + results
 
     if not results:
         resp = await client.chat.completions.create(model=model, messages=messages)

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -175,7 +175,7 @@ _STOP_WORDS = frozenset({
     "about", "into", "than", "more", "also", "has", "have", "had",
 })
 
-_RE_UNLINKED_PREFIX = r"(?<!\[)(?<!\()\b"
+_RE_UNLINKED_PREFIX = r"(?<!\[)\b"
 _RE_UNLINKED_SUFFIX = r"\b(?!\])"
 _RE_FORMULA_CHARS = re.compile(r"[=÷×≥≤≠→←+\-*/\\|^]")
 
@@ -261,6 +261,11 @@ def _inject_citation_links(text: str, citations: list[dict]) -> str:
                 word = text[kw_match.start():kw_match.end()]
                 text = text[:kw_match.start()] + f"[{word}]({url})" + text[kw_match.end():]
                 break
+
+    # Strip any leftover [phrase][N] or bare [N] markers the model wrote for
+    # non-existent citation numbers (model hallucinated a source that wasn't provided).
+    text = re.sub(r"\[([^\]\[]+)\]\s*\[\d+\]", r"\1", text)
+    text = re.sub(r"\[(\d+)\](?!\()", "", text)
 
     return text
 

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -289,29 +289,31 @@ export default function ChatBox({
         activeConvId,
         messageForBackend,
         agents,
-        controller.signal,
-        // onToken — streams main text at 60fps
-        (delta, agent) => {
-          const key = agent ?? "default";
-          setStreamingMap((prev: Record<string, string>) => ({ ...prev, [key]: (prev[key] ?? "") + delta }));
-        },
-        // onDone — fires when main text is finished.
-        // For the first exchange (disableCancel=true at call time), keep pending=true
-        // so chatLoading stays on until finally, blocking quiz submit during follow-up.
-        // For subsequent exchanges, release pending immediately so the user can re-submit
-        // while follow-up questions stream in.
-        (replies) => {
-          textDoneCommitted.current = true;
-          setMessages(m => [...m, ...buildBotMsgs(replies)]);
-          onAssistantMessage?.(replies[replies.length - 1]);
-          if (!disableCancel) setPending(false);
-          setFollowupActive(true);
-          setStreamingMap({});
-        },
-        // onFollowupToken — streams follow-up question tokens at 60fps
-        (delta) => {
-          followupStreamTextRef.current += delta;
-          setFollowupStreamText(prev => prev + delta);
+        {
+          signal: controller.signal,
+          // onToken — streams main text at 60fps
+          onToken: (delta, agent) => {
+            const key = agent ?? "default";
+            setStreamingMap((prev: Record<string, string>) => ({ ...prev, [key]: (prev[key] ?? "") + delta }));
+          },
+          // onDone — fires when main text is finished.
+          // For the first exchange (disableCancel=true at call time), keep pending=true
+          // so chatLoading stays on until finally, blocking quiz submit during follow-up.
+          // For subsequent exchanges, release pending immediately so the user can re-submit
+          // while follow-up questions stream in.
+          onDone: (replies) => {
+            textDoneCommitted.current = true;
+            setMessages(m => [...m, ...buildBotMsgs(replies)]);
+            onAssistantMessage?.(replies[replies.length - 1]);
+            if (!disableCancel) setPending(false);
+            setFollowupActive(true);
+            setStreamingMap({});
+          },
+          // onFollowupToken — streams follow-up question tokens at 60fps
+          onFollowupToken: (delta) => {
+            followupStreamTextRef.current += delta;
+            setFollowupStreamText(prev => prev + delta);
+          },
         },
       );
 

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -41,17 +41,51 @@ export async function signup(data: SignupPayload) {
 }
 
 export async function login(email: string, password: string) {
+  invalidateMeCache();
   return apiFetch<{ user: User }>("/auth/login", {
     method: "POST",
     body: JSON.stringify({ email, password }),
   });
 }
 
+// ---------------------------------------------------------------------------
+// getMe() deduplication + short-lived cache
+// - In-flight dedup: two calls fired at the same time (React StrictMode double
+//   mount) share one network request instead of making two.
+// - TTL cache: page navigations within 30 s skip the network entirely.
+// - Invalidated by logout() and login() so stale data never lingers.
+// ---------------------------------------------------------------------------
+const ME_TTL_MS = 30_000;
+
+let _meCache: { value: { user: User }; ts: number } | null = null;
+let _mePending: Promise<{ user: User }> | null = null;
+
+export function invalidateMeCache() {
+  _meCache = null;
+  _mePending = null;
+}
+
 export async function getMe() {
-  return apiFetch<{ user: User }>("/auth/me");
+  const now = Date.now();
+  if (_meCache && now - _meCache.ts < ME_TTL_MS) {
+    return _meCache.value;
+  }
+  if (_mePending) return _mePending;
+  _mePending = apiFetch<{ user: User }>("/auth/me")
+    .then((res) => {
+      _meCache = { value: res, ts: Date.now() };
+      _mePending = null;
+      return res;
+    })
+    .catch((e) => {
+      _mePending = null;
+      throw e;
+    });
+  return _mePending;
 }
 
 export async function logout() {
+  invalidateMeCache();
   return apiFetch<void>("/auth/logout", { method: "POST" });
 }
 

--- a/frontend/lib/chat.ts
+++ b/frontend/lib/chat.ts
@@ -1,5 +1,29 @@
 import { apiFetch } from "./fetcher";
 
+export interface Citation {
+  n: number;
+  title: string;
+  url: string;
+}
+
+export function injectCitationLinks(text: string, citations: Citation[]): string {
+  let result = text;
+  for (const { n, url } of citations) {
+    const N = String(n);
+    // Primary: [key phrase][N] or [key phrase] [N] → [key phrase](url)
+    result = result.replaceAll(
+      new RegExp(String.raw`\[([^\]\[]+)\]\s*\[${N}\]`, "g"),
+      `[$1](${url})`,
+    );
+    // Fallback: bare [N] not already followed by ( → [N](url)
+    result = result.replaceAll(
+      new RegExp(String.raw`\[${N}\](?!\()`, "g"),
+      `[${N}](${url})`,
+    );
+  }
+  return result;
+}
+
 export interface AIMessageMetadata {
   sources?: string[];
   confidence_score?: number;
@@ -25,16 +49,22 @@ export async function loadUserHistory(conversationId: string): Promise<{
   return apiFetch(`/api/chat/load_user_history/${conversationId}`);
 }
 
+export interface SendChatOptions {
+  signal?: AbortSignal;
+  onToken?: (delta: string, agent?: string) => void;
+  onDone?: (replies: string[], convId: string) => void;
+  onFollowupToken?: (delta: string) => void;
+  onCitations?: (citations: Citation[]) => void;
+}
+
 export async function sendChat(
   quizId: string,
   conversationId: string | null,
   message: string,
   agents: string[] = [],
-  signal?: AbortSignal,
-  onToken?: (delta: string, agent?: string) => void,
-  onDone?: (replies: string[], convId: string) => void,
-  onFollowupToken?: (delta: string) => void,
+  options: SendChatOptions = {},
 ): Promise<ChatResponse> {
+  const { signal, onToken, onDone, onFollowupToken, onCitations } = options;
   const resp = await fetch(`/api/chat/${quizId}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -59,6 +89,7 @@ export async function sendChat(
   const replyMap: Record<string, string> = {};
   let returnedConvId = conversationId ?? "";
   let followupQuestions: string[] | undefined;
+  let citations: Citation[] = [];
 
   // Batch token updates: flush to React at most once per animation frame (~16ms).
   // This avoids one re-render per token while keeping streaming visually smooth.
@@ -109,14 +140,20 @@ export async function sendChat(
             // Batch questions (backwards compat for endpoints that send the full array).
             followupQuestions = [...(followupQuestions ?? []), ...(event.questions as string[])];
           }
+        } else if (event.type === "citations") {
+          citations = (event.citations as Citation[]) ?? [];
+          onCitations?.(citations);
         } else if (event.type === "done") {
           returnedConvId = (event.conversation_id as string) ?? returnedConvId;
           if (onDone) {
             flushTokens();
             const agentKeys = Object.keys(replyMap).filter(k => k !== "default").sort();
-            const replies = agentKeys.length > 0
+            const rawReplies = agentKeys.length > 0
               ? agentKeys.map(k => replyMap[k])
               : [replyMap["default"] ?? ""];
+            const replies = citations.length > 0
+              ? rawReplies.map(r => injectCitationLinks(r, citations))
+              : rawReplies;
             onDone(replies, returnedConvId);
           }
         } else if (event.type === "error") {
@@ -131,9 +168,12 @@ export async function sendChat(
   }
 
   const agentKeys = Object.keys(replyMap).filter(k => k !== "default").sort();
-  const replies = agentKeys.length > 0
+  const rawReplies = agentKeys.length > 0
     ? agentKeys.map(k => replyMap[k])
     : [replyMap["default"] ?? ""];
+  const replies = citations.length > 0
+    ? rawReplies.map(r => injectCitationLinks(r, citations))
+    : rawReplies;
 
   return { replies, conversationId: returnedConvId, followupQuestions };
 }

--- a/frontend/lib/chat.ts
+++ b/frontend/lib/chat.ts
@@ -147,13 +147,19 @@ export async function sendChat(
           returnedConvId = (event.conversation_id as string) ?? returnedConvId;
           if (onDone) {
             flushTokens();
-            const agentKeys = Object.keys(replyMap).filter(k => k !== "default").sort();
-            const rawReplies = agentKeys.length > 0
-              ? agentKeys.map(k => replyMap[k])
-              : [replyMap["default"] ?? ""];
-            const replies = citations.length > 0
-              ? rawReplies.map(r => injectCitationLinks(r, citations))
-              : rawReplies;
+            const backendReply = event.reply as string | undefined;
+            let replies: string[];
+            if (backendReply === undefined) {
+              const agentKeys = Object.keys(replyMap).filter(k => k !== "default").sort((a, b) => a.localeCompare(b));
+              const rawReplies = agentKeys.length > 0
+                ? agentKeys.map(k => replyMap[k])
+                : [replyMap["default"] ?? ""];
+              replies = citations.length > 0
+                ? rawReplies.map(r => injectCitationLinks(r, citations))
+                : rawReplies;
+            } else {
+              replies = [backendReply];
+            }
             onDone(replies, returnedConvId);
           }
         } else if (event.type === "error") {

--- a/frontend/pages/chat.tsx
+++ b/frontend/pages/chat.tsx
@@ -18,14 +18,14 @@ export default function ChatPage() {
         if (!cancel) {
           if (!res.user.is_admin) {
             // Non-admin → block access and redirect
-            window.location.href = "/dashboard";
+            router.replace("/dashboard");
             return;
           }
           setUser(res.user);
         }
       } catch {
         // Not logged in → send to login
-        if (!cancel) window.location.href = "/login";
+        if (!cancel) router.replace("/login");
       } finally {
         if (!cancel) setChecking(false);
       }

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -27,7 +27,7 @@ export default function DashboardPage() {
       }
     })();
     return () => { cancelled = true; };
-  }, [router]);
+  }, []);
 
   if (checking) {
     return (

--- a/frontend/pages/demographics.tsx
+++ b/frontend/pages/demographics.tsx
@@ -1,7 +1,7 @@
 //
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { getMe, logout, type User } from "../lib/auth";
+import { getMe, invalidateMeCache, logout, type User } from "../lib/auth";
 import { saveMyDemographics } from "../lib/demographics";
 
 export default function DemographicsPage() {
@@ -56,7 +56,7 @@ export default function DemographicsPage() {
     return () => {
       cancel = true;
     };
-  }, [router]);
+  }, []);
 
   if (checking) {
     return (
@@ -122,6 +122,7 @@ export default function DemographicsPage() {
         class_name: className.trim() || undefined,
         age: String(parsedAge),
       });
+      invalidateMeCache();
       router.replace("/dashboard");
     } catch (e) {
       console.error(e);

--- a/frontend/pages/links_panel.tsx
+++ b/frontend/pages/links_panel.tsx
@@ -52,13 +52,13 @@ export default function LinkPanelPage() {
         if (cancel) return;
 
         if (!res.user.is_admin) {
-          window.location.href = "/dashboard";
+          router.replace("/dashboard");
           return;
         }
 
         setUser(res.user);
       } catch {
-        if (!cancel) window.location.href = "/login";
+        if (!cancel) router.replace("/login");
       } finally {
         if (!cancel) setChecking(false);
       }

--- a/frontend/pages/playground.tsx
+++ b/frontend/pages/playground.tsx
@@ -28,14 +28,14 @@ export default function Playground() {
         if (!cancel) {
           if (!res.user.is_admin) {
             // Non-admin → block access and redirect
-            window.location.href = "/dashboard";
+            router.replace("/dashboard");
             return;
           }
           setUser(res.user);
         }
       } catch {
         // Not logged in → send to login
-        if (!cancel) window.location.href = "/login";
+        if (!cancel) router.replace("/login");
       } finally {
         if (!cancel) setChecking(false);
       }

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -38,7 +38,7 @@ export default function ProfilePage() {
     return () => {
       cancel = true;
     };
-  }, [router]);
+  }, []);
 
   if (checking) {
     return (

--- a/frontend/pages/quiz/[quiz_id].tsx
+++ b/frontend/pages/quiz/[quiz_id].tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import QuestionBox, { Choice } from "../../components/QuestionBox";
-import { getMe, logout, type User } from "../../lib/auth";
+import { getMe, invalidateMeCache, logout, type User } from "../../lib/auth";
 import {
   getQuizState,
   submitQuizAnswer,
@@ -21,7 +21,7 @@ type VariantQuizId = (typeof VARIANT_QUIZ_IDS)[number];
 type QuizId = "base" | VariantQuizId;
 
 type ExtendedUser = User & {
-  assigned_var?: VariantQuizId | string | null;
+  assigned_var?: string | null;
   survey_stage?: SurveyStage | null;
   survey_pre_base_completed?: boolean;
   quiz_base_completed?: boolean;
@@ -165,7 +165,7 @@ export default function QuizPage() {
     return () => {
       cancel = true;
     };
-  }, [router, router.isReady, rawQuizId, quizId]);
+  }, [router.isReady, rawQuizId, quizId]);
 
   useEffect(() => {
     if (!user) return;
@@ -219,6 +219,7 @@ export default function QuizPage() {
   async function redirectAfterCompletion() {
     if (!quizId) return;
     try {
+      invalidateMeCache();
       const res = await getMe();
       const refreshedUser = res.user as ExtendedUser;
 
@@ -382,6 +383,7 @@ export default function QuizPage() {
                 onReset={user.is_admin ? async () => {
                   if (!quizId) return;
                   await resetQuiz(quizId);
+                  invalidateMeCache();
                   const state = await getQuizState(quizId);
                   setQuizState(state);
                   setSelectedChoice(null);

--- a/frontend/pages/survey.tsx
+++ b/frontend/pages/survey.tsx
@@ -1,7 +1,7 @@
 // frontend/pages/survey.tsx
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
-import { getMe, logout, type User } from "../lib/auth";
+import { getMe, invalidateMeCache, logout, type User } from "../lib/auth";
 import {
   getSurveyState,
   submitSurvey,
@@ -207,7 +207,7 @@ export default function SurveyPage() {
     return () => {
       cancel = true;
     };
-  }, [router]);
+  }, []);
 
   useEffect(() => {
     if (!user) return;
@@ -249,6 +249,7 @@ export default function SurveyPage() {
         setValues(initial);
 
         if (responseState.status === "completed") {
+          invalidateMeCache();
           const refreshed = await getMe();
           if (cancel) return;
           router.replace(
@@ -267,7 +268,7 @@ export default function SurveyPage() {
     return () => {
       cancel = true;
     };
-  }, [user, activeSurveyStage, loadStage, config, quiz_id, router]);
+  }, [user, activeSurveyStage, loadStage, config, quiz_id]);
 
   const requiredUnanswered = useMemo(() => {
     return items
@@ -312,6 +313,7 @@ export default function SurveyPage() {
       // Submit under the actual active stage.
       // For post_variant, this saves under post_variant.
       await submitSurvey(activeSurveyStage, answers);
+      invalidateMeCache();
 
       const optimisticUser: ExtendedUser | null =
         user &&

--- a/frontend/pages/surveys_panel.tsx
+++ b/frontend/pages/surveys_panel.tsx
@@ -102,12 +102,12 @@ export default function SurveyPanelPage() {
         if (cancel) return;
 
         if (!res.user.is_admin) {
-          window.location.href = "/dashboard";
+          router.replace("/dashboard");
           return;
         }
         setUser(res.user);
       } catch {
-        if (!cancel) window.location.href = "/login";
+        if (!cancel) router.replace("/login");
       } finally {
         if (!cancel) setChecking(false);
       }


### PR DESCRIPTION
- Loads links from the database at runtime and injects them into the citation context for the model, working without having to use a specific search tool. 
- Added text streaming per token to match the logic for the rest of the quiz cases (before was using a fake streaming as a placeholder that still waited for the full message to print
- Uses only links from the database. Commented out the external search due to the litellm search tool being deprecated. Works fine for this app because we have full control over the links that show up and can hand-select them to match the specific questions well. 
- Added a function to ensure that citations are done in-line, more readable, and not done as extra text at the end of the phrase to match. Finds previous words that match one of the words or phrases in the wrapped phrase chosen by the LLM and wraps the citation around the earlier phrase instead. 
- Safeguards to prevent wrapping functions or conflicting regex with citations. 
- Citation handling while text is streaming is handled by the frontend, replaced by the full backend version when the done stream event is passed. This works across all quiz types in case the user suggests links in other quiz variants (edge case) and avoids rewriting large chunks of code for just the links case. 

## Additional fixes and features
- Fixed duplicate routing calls for OAuth and pages. Before, pages were called multiple times when different parts of the page were loaded, now only once. Caching is used to preserve session identity over short intervals when changing routing. 
- Session duration increased from 1 hour to 3 hours in case it takes users longer to complete everything. 
- .env.example
- Admin routes use router.replace instead of window.location.href to run faster and avoid having to do a full reload. Stays consistent across the whole app. 