### PR TITLE
UI Overhaul, Study Flow Centralization & Chat Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ Thumbs.db
 .vscode/
 .idea/
 __pycache__
+
+# Claude files
+claude/
+.claude/
+

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -199,6 +199,7 @@ async def _standard_stream(
     request: Optional[Request] = None,
     agent_tag: Optional[str] = None,
     reply_prefix: str = "",
+    answer_incorrectly: bool = False,
 ) -> AsyncGenerator[str, None]:
     """Stream tokens, fire-and-forget saves, emit done, then optionally yield from after_done.
 
@@ -213,8 +214,9 @@ async def _standard_stream(
         full_reply += delta
 
     stored_reply = f"{reply_prefix}{full_reply}" if reply_prefix else full_reply
+    metadata = AIMessageMetadata(answer_incorrectly=answer_incorrectly)
     asyncio.create_task(asyncio.to_thread(_save_message, col, "user", user, conv_id, user_message))
-    asyncio.create_task(asyncio.to_thread(_save_message, col, "assistant", user, conv_id, [stored_reply]))
+    asyncio.create_task(asyncio.to_thread(_save_message, col, "assistant", user, conv_id, [stored_reply], metadata.model_dump(exclude_none=True)))
     yield _sse({"type": "done", "conversation_id": conv_id})
 
     if after_done and not (request and await request.is_disconnected()):
@@ -294,7 +296,8 @@ async def double_chat(
         msgs = messages_a if run_agent_a else messages_b
         return StreamingResponse(
             _standard_stream(msgs, col, user, conv_id, req.message,
-                             agent_tag=tag, reply_prefix=f"[AGENT {tag}] "),
+                             agent_tag=tag, reply_prefix=f"[AGENT {tag}] ",
+                             answer_incorrectly=req.answer_incorrectly),
             media_type="text/event-stream",
             headers=_SSE_HEADERS,
         )
@@ -325,8 +328,9 @@ async def double_chat(
             replies[tag] += delta
 
         replies_to_store = [f"[AGENT A] {replies['A']}", f"[AGENT B] {replies['B']}"]
+        metadata = AIMessageMetadata(answer_incorrectly=req.answer_incorrectly).model_dump(exclude_none=True)
         asyncio.create_task(asyncio.to_thread(_save_message, col, "user", user, conv_id, req.message))
-        asyncio.create_task(asyncio.to_thread(_save_message, col, "assistant", user, conv_id, replies_to_store))
+        asyncio.create_task(asyncio.to_thread(_save_message, col, "assistant", user, conv_id, replies_to_store, metadata))
         yield _sse({"type": "done", "conversation_id": conv_id})
 
     return StreamingResponse(generate(), media_type="text/event-stream", headers=_SSE_HEADERS)
@@ -344,14 +348,18 @@ async def followup_quiz_chat(
     conv_id = req.conversation_id or str(uuid.uuid4())
     history = await asyncio.to_thread(get_last_exchange, request.app.state.messages, conv_id)
     col = request.app.state.messages
-    messages = _build_standard_messages(history, req.message)
+    system_instruction = _build_system_instruction(
+        answer_incorrectly=req.answer_incorrectly,
+        has_choices=len(req.answer_choices) > 0,
+    )
+    messages = _build_standard_messages(history, req.message, system_prompt=system_instruction)
 
     async def after_done(full_reply: str) -> AsyncGenerator[str, None]:
         async for delta in generate_followup_questions(full_reply, _stream_ai):
             yield _sse({"type": "followup", "token": delta})
 
     return StreamingResponse(
-        _standard_stream(messages, col, user, conv_id, req.message, after_done=after_done, request=request),
+        _standard_stream(messages, col, user, conv_id, req.message, after_done=after_done, request=request, answer_incorrectly=req.answer_incorrectly),
         media_type="text/event-stream",
         headers=_SSE_HEADERS,
     )
@@ -374,7 +382,10 @@ async def chat_with_embedded_links(
     history = await asyncio.to_thread(get_last_exchange, request.app.state.messages, conv_id)
 
     system_instruction = (
-        _BASE_SYSTEM_PROMPT +
+        _build_system_instruction(
+            answer_incorrectly=req.answer_incorrectly,
+            has_choices=len(req.answer_choices) > 0,
+        ) +
         " Use web searches to gather information and cite sources inline."
         "Prioritize academic and institutional sources; avoid blog posts, news articles, or unverifiable sources."
         "Prefer sources with stable, long-lived URLs."
@@ -412,8 +423,9 @@ async def chat_with_embedded_links(
             yield _sse({"type": "token", "content": word + ("" if i == len(words) - 1 else " ")})
 
         # OPTIMIZATION: Non-blocking database saves (fire-and-forget)
+        metadata = AIMessageMetadata(answer_incorrectly=req.answer_incorrectly).model_dump(exclude_none=True)
         asyncio.create_task(asyncio.to_thread(_save_message, request.app.state.messages, "user", user, conv_id, req.message))
-        asyncio.create_task(asyncio.to_thread(_save_message, request.app.state.messages, "assistant", user, conv_id, [reply]))
+        asyncio.create_task(asyncio.to_thread(_save_message, request.app.state.messages, "assistant", user, conv_id, [reply], metadata))
         
         yield _sse({"type": "done", "conversation_id": conv_id})
 
@@ -434,10 +446,14 @@ async def chat(
     conv_id = req.conversation_id or str(uuid.uuid4())
     history = await asyncio.to_thread(get_last_exchange, request.app.state.messages, conv_id)
     col = request.app.state.messages
-    messages = _build_standard_messages(history, req.message)
+    system_instruction = _build_system_instruction(
+        answer_incorrectly=req.answer_incorrectly,
+        has_choices=len(req.answer_choices) > 0,
+    )
+    messages = _build_standard_messages(history, req.message, system_prompt=system_instruction)
 
     return StreamingResponse(
-        _standard_stream(messages, col, user, conv_id, req.message),
+        _standard_stream(messages, col, user, conv_id, req.message, answer_incorrectly=req.answer_incorrectly),
         media_type="text/event-stream",
         headers=_SSE_HEADERS,
     )

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -49,6 +49,10 @@ class AIMessageMetadata(BaseModel):
         default=None,
         description="Tokens generated in the response"
     )
+    answer_incorrectly: Optional[bool] = Field(
+        default=None,
+        description="Whether the AI was instructed to answer incorrectly"
+    )
     custom_metadata: Optional[dict[str, Any]] = Field(
         default=None,
         description="Flexible field for any additional metadata or analysis data"

--- a/backend/app/schemas/quiz.py
+++ b/backend/app/schemas/quiz.py
@@ -27,6 +27,7 @@ class QuizAttemptPublic(BaseModel):
     status: str  # "in_progress" or "completed"
     total_questions: int
     answered_count: int
+    incorrect_question_ids: list[str] = []
 
 
 # The question data sent to the client for the current unanswered question.

--- a/backend/app/services/quiz.py
+++ b/backend/app/services/quiz.py
@@ -49,9 +49,7 @@ def _load_or_create_attempt(db, user_id: str, user_email: str, quiz_id: str) -> 
     random.shuffle(ids)
 
     ids = ids[:MAX_QUIZ_QUESTIONS]
-
-    incorrect_count = random.randint(3, min(5,len(ids)))
-    incorrect_question_ids = random.sample(ids, incorrect_count)
+    incorrect_question_ids = random.sample(ids, min(3, len(ids)))
 
     now = datetime.utcnow()
     doc = {
@@ -61,6 +59,7 @@ def _load_or_create_attempt(db, user_id: str, user_email: str, quiz_id: str) -> 
         "conversation_id": str(uuid.uuid4()),
         "status": "in_progress",
         "question_order": ids,
+        "incorrect_question_ids": incorrect_question_ids,
         "answers": [],
         "created_at": now,
         "updated_at": now,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
+      - next_cache:/app/.next
     environment:
       - NODE_ENV=development
       - WATCHPACK_POLLING=true
@@ -49,5 +50,6 @@ services:
 #       - mongo_data:/data/db
 #     restart: unless-stopped
 
-# volumes:
+volumes:
+  next_cache:
 #   mongo_data:

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -61,7 +61,7 @@ const MessageBubble = memo(function MessageBubble({
   return (
     <div>
       {showLabel && (
-        <div className={`text-xs text-gray-600 px-1 mb-1 ${computedLabelAlign === "center" ? "text-center" : computedLabelAlign === "right" ? "text-right" : "text-left"}`}>
+        <div className={`text-sm text-gray-600 px-1 mb-1 ${computedLabelAlign === "center" ? "text-center" : computedLabelAlign === "right" ? "text-right" : "text-left"}`}>
           {label}
         </div>
       )}
@@ -523,7 +523,7 @@ export default function ChatBox({
         const bubbleClass = bot ? BOT_COLORS[bot] : "bg-gray-100 text-gray-900";
         return (
           <div key={`streaming-${agentKey}`}>
-            <div className="text-xs text-gray-600 px-1 mb-1 text-left">{label}</div>
+            <div className="text-sm text-gray-600 px-1 mb-1 text-left">{label}</div>
             <div className="flex justify-start">
               <div className={`max-w-[95%] rounded-2xl px-4 py-2 ${bubbleClass}`}>
                 <MarkdownMessage content={content} />
@@ -581,21 +581,21 @@ export default function ChatBox({
           <div className="mt-3 border-t border-gray-200 pt-3">
             <div className="mb-2 text-lg font-semibold text-gray-900">Follow-up Questions</div>
             {(followupActive || followupStreamText !== "") && !followupQuestions?.length && !followupInProgress ? (
-              <div className="text-sm text-gray-500">Loading follow-up questions…</div>
+              <div className="text-base text-gray-500">Loading follow-up questions…</div>
             ) : (
               <div className="flex flex-wrap gap-2">
                 {followupQuestions?.map((q, i) => (
                   <button
                     key={i}
                     type="button"
-                    className="text-[0.8125rem] px-3 py-1 rounded-full border border-gray-300 bg-white hover:bg-gray-100 transition"
+                    className="text-sm px-3 py-1.5 rounded-full border border-gray-300 bg-white hover:bg-gray-100 transition"
                     onClick={() => handleFollowupClick(q)}
                   >
                     <MarkdownMessage content={q} inline />
                   </button>
                 ))}
                 {followupInProgress && !followupQuestions?.includes(followupInProgress) && (
-                  <span className="text-[0.8125rem] px-3 py-1 rounded-full border border-gray-200 bg-gray-50 text-gray-400 italic">
+                  <span className="text-sm px-3 py-1.5 rounded-full border border-gray-200 bg-gray-50 text-gray-400 italic">
                     {followupInProgress}
                   </span>
                 )}
@@ -605,13 +605,13 @@ export default function ChatBox({
         )}
 
         {pending && !followupActive && Object.keys(streamingMap).length === 0 && (
-          <div className="text-sm text-gray-500">Assistant is typing…</div>
+          <div className="text-base text-gray-500">Assistant is typing…</div>
         )}
 
         {renderStreaming()}
 
         {error && (
-          <div role="alert" className="text-sm text-red-600">
+          <div role="alert" className="text-base text-red-600">
             {error}
           </div>
         )}
@@ -628,7 +628,7 @@ export default function ChatBox({
         <div className="flex items-end gap-2">
           <textarea
             ref={textareaRef}
-            className="w-full resize-none rounded-xl border px-3 py-2 focus:outline-none focus:ring text-gray-900"
+            className="w-full resize-none rounded-xl border px-3 py-2 focus:outline-none focus:ring text-base text-gray-900"
             placeholder="Type a message…"
             value={input}
             onChange={handleInputChange}
@@ -636,7 +636,7 @@ export default function ChatBox({
             rows={2}
           />
           <button
-            className={`rounded-xl px-4 py-2 font-medium text-white ${pending && disableCancel ? "bg-gray-400 cursor-default" : pending ? "bg-red-600 hover:bg-red-700" : "bg-accent-600 disabled:opacity-60"}`}
+            className={`rounded-xl px-4 py-2 text-base font-medium text-white ${pending && disableCancel ? "bg-gray-400 cursor-default" : pending ? "bg-red-600 hover:bg-red-700" : "bg-accent-600 disabled:opacity-60"}`}
             onClick={pending && !disableCancel ? handleCancel : onSend}
             disabled={disableCancel || (!pending && !input.trim())}
           >

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -3,6 +3,7 @@ import { memo, useEffect, useRef, useState } from "react";
 import { sendChat, loadUserHistory } from "../lib/chat";
 import MarkdownMessage from "./MarkdownMessage";
 import MentionSuggestions from "./MentionSuggestions";
+import ChatHeader from "./ChatHeader";
 import {
   getFilteredAgents,
   getPartialMention,
@@ -49,7 +50,7 @@ const MessageBubble = memo(function MessageBubble({
   const label = role === "user" ? "You" : bot ? `Agent ${bot}` : "Assistant";
   const bubbleClass =
     role === "user"
-      ? "bg-blue-600 text-white"
+      ? "bg-accent-600 text-white"
       : bot
         ? BOT_COLORS[bot]
         : "bg-gray-100 text-gray-900";
@@ -563,41 +564,12 @@ export default function ChatBox({
   };
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col rounded-2xl border bg-white shadow-sm overflow-hidden">
-      <div className="px-4 py-3 border-b sticky top-0 bg-white/90 backdrop-blur rounded-t-2xl flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-600">
-            <svg className="h-5 w-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-              <path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-            </svg>
-          </div>
-          <h2 className="text-xl font-semibold text-gray-900 2xl:text-2xl">AI Assistant</h2>
-        </div>
-        {onToggleQuestion && (
-          <button
-            type="button"
-            className="md:hidden inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600 shadow-sm transition hover:bg-gray-50 hover:text-gray-900 active:scale-95"
-            onClick={onToggleQuestion}
-            aria-label={questionCollapsed ? "Minimize question" : "Maximize question"}
-          >
-            {questionCollapsed ? (
-              <>
-                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                </svg>
-                Minimize
-              </>
-            ) : (
-              <>
-                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
-                </svg>
-                Maximize
-              </>
-            )}
-          </button>
-        )}
-      </div>
+    <div data-quiz-theme={quizId} className="flex h-full min-h-0 w-full flex-col rounded-2xl border bg-white shadow-sm overflow-hidden">
+      <ChatHeader
+        quizId={quizId}
+        questionCollapsed={questionCollapsed}
+        onToggleQuestion={onToggleQuestion}
+      />
 
       <div
         ref={scrollerRef}
@@ -664,7 +636,7 @@ export default function ChatBox({
             rows={2}
           />
           <button
-            className={`rounded-xl px-4 py-2 font-medium text-white ${pending && disableCancel ? "bg-gray-400 cursor-default" : pending ? "bg-red-600 hover:bg-red-700" : "bg-blue-600 disabled:opacity-60"}`}
+            className={`rounded-xl px-4 py-2 font-medium text-white ${pending && disableCancel ? "bg-gray-400 cursor-default" : pending ? "bg-red-600 hover:bg-red-700" : "bg-accent-600 disabled:opacity-60"}`}
             onClick={pending && !disableCancel ? handleCancel : onSend}
             disabled={disableCancel || (!pending && !input.trim())}
           >

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -88,6 +88,8 @@ type ChatBoxProps = {
   disableCancel?: boolean;
   questionCollapsed?: boolean;
   onToggleQuestion?: () => void;
+  answerIncorrectly?: boolean;
+  answerChoices?: { id: string; label: string }[];
 };
 
 export default function ChatBox({
@@ -101,6 +103,8 @@ export default function ChatBox({
   disableCancel = false,
   questionCollapsed,
   onToggleQuestion,
+  answerIncorrectly = false,
+  answerChoices,
 }: ChatBoxProps) {
   const agentFilter: AgentFilter = quizId === "double" ? "double" : "base";
   const [messages, setMessages] = useState<Msg[]>([]);
@@ -313,6 +317,8 @@ export default function ChatBox({
           followupStreamTextRef.current += delta;
           setFollowupStreamText(prev => prev + delta);
         },
+        answerIncorrectly,
+        answerChoices,
       );
 
       if (returnedConvId && !activeConvId) setActiveConvId(returnedConvId);

--- a/frontend/components/ChatHeader.tsx
+++ b/frontend/components/ChatHeader.tsx
@@ -66,7 +66,7 @@ export default function ChatHeader({
   }, [showInfo]);
 
   return (
-    <div className="px-4 py-3 border-b sticky top-0 bg-white/90 backdrop-blur rounded-t-2xl flex items-center justify-between gap-3">
+    <div className="px-4 py-4 border-b sticky top-0 bg-white/90 backdrop-blur rounded-t-2xl flex items-center justify-between gap-3">
       <div className="flex items-center gap-2">
         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-600">
           <svg
@@ -82,7 +82,7 @@ export default function ChatHeader({
           </svg>
         </div>
 
-        <h2 className="text-xl font-semibold text-gray-900 2xl:text-2xl">
+        <h2 className="text-2xl font-semibold text-gray-900 2xl:text-3xl">
           AI Assistant
           {theme.id !== "base" && (
             <span className="font-normal text-gray-500">
@@ -111,12 +111,12 @@ export default function ChatHeader({
                   ? { position: "fixed", top: popoverPos.top, left: popoverPos.left }
                   : { position: "fixed", visibility: "hidden", top: 0, left: 0 }
               }
-              className="z-50 w-72 max-w-[calc(100vw-1rem)] rounded-xl border bg-white p-4 shadow-lg"
+              className="z-50 w-96 max-w-[calc(100vw-2rem)] rounded-xl border bg-white p-5 shadow-lg"
             >
-              <div className="flex items-center gap-2 mb-2">
-                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-600">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-600">
                   <svg
-                    className="h-3.5 w-3.5 text-white"
+                    className="h-5 w-5 text-white"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -127,12 +127,12 @@ export default function ChatHeader({
                     <path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
                   </svg>
                 </div>
-                <span className="font-semibold text-gray-900">{theme.subtitle}</span>
+                <span className="text-lg font-semibold text-gray-900">{theme.subtitle}</span>
               </div>
-              <p className="text-sm text-gray-600 leading-relaxed">
+              <p className="text-base text-gray-600 leading-relaxed">
                 {theme.description}
               </p>
-              <p className="mt-3 text-xs text-gray-400 leading-relaxed border-t border-gray-100 pt-2">
+              <p className="mt-3 text-sm text-gray-400 leading-relaxed border-t border-gray-100 pt-3">
                 AI can make mistakes. Always verify important information and use your own judgment when answering.
               </p>
             </div>,

--- a/frontend/components/ChatHeader.tsx
+++ b/frontend/components/ChatHeader.tsx
@@ -1,5 +1,6 @@
 // frontend/components/ChatHeader.tsx
 import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { getQuizTheme } from "../lib/quizTheme";
 
 type ChatHeaderProps = {
@@ -15,8 +16,38 @@ export default function ChatHeader({
 }: ChatHeaderProps) {
   const theme = getQuizTheme(quizId);
   const [showInfo, setShowInfo] = useState(false);
+  const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!showInfo) {
+      setPopoverPos(null);
+      return;
+    }
+
+    const raf = requestAnimationFrame(() => {
+      if (!buttonRef.current || !popoverRef.current) return;
+      const btn = buttonRef.current.getBoundingClientRect();
+      const pop = popoverRef.current.getBoundingClientRect();
+      const margin = 8;
+
+      let left = btn.left;
+      if (left + pop.width > window.innerWidth - margin) {
+        left = window.innerWidth - margin - pop.width;
+      }
+      left = Math.max(margin, left);
+
+      let top = btn.bottom + 8;
+      if (top + pop.height > window.innerHeight - margin) {
+        top = btn.top - pop.height - 8;
+      }
+
+      setPopoverPos({ top, left });
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [showInfo]);
 
   useEffect(() => {
     if (!showInfo) return;
@@ -71,10 +102,16 @@ export default function ChatHeader({
             ?
           </button>
 
-          {showInfo && (
+          {showInfo && createPortal(
             <div
               ref={popoverRef}
-              className="absolute left-0 top-full mt-2 z-50 w-72 rounded-xl border bg-white p-4 shadow-lg"
+              data-quiz-theme={quizId}
+              style={
+                popoverPos
+                  ? { position: "fixed", top: popoverPos.top, left: popoverPos.left }
+                  : { position: "fixed", visibility: "hidden", top: 0, left: 0 }
+              }
+              className="z-50 w-72 max-w-[calc(100vw-1rem)] rounded-xl border bg-white p-4 shadow-lg"
             >
               <div className="flex items-center gap-2 mb-2">
                 <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-600">
@@ -98,7 +135,8 @@ export default function ChatHeader({
               <p className="mt-3 text-xs text-gray-400 leading-relaxed border-t border-gray-100 pt-2">
                 AI can make mistakes. Always verify important information and use your own judgment when answering.
               </p>
-            </div>
+            </div>,
+            document.body
           )}
         </div>
       </div>

--- a/frontend/components/ChatHeader.tsx
+++ b/frontend/components/ChatHeader.tsx
@@ -1,0 +1,132 @@
+// frontend/components/ChatHeader.tsx
+import { useState, useRef, useEffect } from "react";
+import { getQuizTheme } from "../lib/quizTheme";
+
+type ChatHeaderProps = {
+  quizId: string;
+  questionCollapsed?: boolean;
+  onToggleQuestion?: () => void;
+};
+
+export default function ChatHeader({
+  quizId,
+  questionCollapsed,
+  onToggleQuestion,
+}: ChatHeaderProps) {
+  const theme = getQuizTheme(quizId);
+  const [showInfo, setShowInfo] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!showInfo) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target as Node)
+      ) {
+        setShowInfo(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showInfo]);
+
+  return (
+    <div className="px-4 py-3 border-b sticky top-0 bg-white/90 backdrop-blur rounded-t-2xl flex items-center justify-between gap-3">
+      <div className="flex items-center gap-2">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-600">
+          <svg
+            className="h-5 w-5 text-white"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+          </svg>
+        </div>
+
+        <h2 className="text-xl font-semibold text-gray-900 2xl:text-2xl">
+          AI Assistant
+          {theme.id !== "base" && (
+            <span className="font-normal text-gray-500">
+              {" "}&middot; {theme.subtitle}
+            </span>
+          )}
+        </h2>
+
+        <div className="relative">
+          <button
+            ref={buttonRef}
+            type="button"
+            onClick={() => setShowInfo((v) => !v)}
+            className="flex h-5 w-5 items-center justify-center rounded-full border border-gray-300 text-xs font-bold text-gray-500 hover:bg-gray-100 hover:text-gray-700 transition"
+            aria-label="About this assistant type"
+          >
+            ?
+          </button>
+
+          {showInfo && (
+            <div
+              ref={popoverRef}
+              className="absolute left-0 top-full mt-2 z-50 w-72 rounded-xl border bg-white p-4 shadow-lg"
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-600">
+                  <svg
+                    className="h-3.5 w-3.5 text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+                  </svg>
+                </div>
+                <span className="font-semibold text-gray-900">{theme.subtitle}</span>
+              </div>
+              <p className="text-sm text-gray-600 leading-relaxed">
+                {theme.description}
+              </p>
+              <p className="mt-3 text-xs text-gray-400 leading-relaxed border-t border-gray-100 pt-2">
+                AI can make mistakes. Always verify important information and use your own judgment when answering.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {onToggleQuestion && (
+        <button
+          type="button"
+          className="md:hidden inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600 shadow-sm transition hover:bg-gray-50 hover:text-gray-900 active:scale-95"
+          onClick={onToggleQuestion}
+          aria-label={questionCollapsed ? "Minimize question" : "Maximize question"}
+        >
+          {questionCollapsed ? (
+            <>
+              <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+              Minimize
+            </>
+          ) : (
+            <>
+              <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+              </svg>
+              Maximize
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/MarkdownMessage.tsx
+++ b/frontend/components/MarkdownMessage.tsx
@@ -290,7 +290,7 @@ export default function MarkdownMessage({ content, inline = false, dark = false 
   if (inline) return <span>{rendered}</span>;
 
   return (
-    <div ref={containerRef} className="prose prose-sm text-[0.8125rem] max-w-none break-words [&>*+h2]:mt-5 [&>*+h3]:mt-4 [&>*+h4]:mt-3 [&>p+p]:mt-3">
+    <div ref={containerRef} className="prose prose-base text-base max-w-none break-words [&>*+h2]:mt-5 [&>*+h3]:mt-4 [&>*+h4]:mt-3 [&>p+p]:mt-3">
       {rendered}
     </div>
   );

--- a/frontend/components/MentionSuggestions.tsx
+++ b/frontend/components/MentionSuggestions.tsx
@@ -24,7 +24,7 @@ export default function MentionSuggestions({
             onClick={() => onSelect(agent)}
             className={`w-full text-left px-4 py-2 cursor-pointer ${
               index === selectedIndex
-                ? "bg-blue-500 text-white"
+                ? "bg-accent-500 text-white"
                 : "hover:bg-gray-100"
             }`}
           >

--- a/frontend/components/PageHeader.tsx
+++ b/frontend/components/PageHeader.tsx
@@ -1,0 +1,53 @@
+// frontend/components/PageHeader.tsx
+import React from "react";
+
+type PageHeaderProps = {
+  title: React.ReactNode;
+  subtitle?: string;
+  onLogout: () => void;
+  /** Show "Dashboard" / "Back" primary button — pass the navigation handler */
+  onDashboard?: () => void;
+  /** Show "Profile" primary button instead (dashboard page only) */
+  onProfile?: () => void;
+  /** Extra classes appended to <header> (e.g. "shrink-0") */
+  className?: string;
+};
+
+export default function PageHeader({
+  title,
+  subtitle,
+  onLogout,
+  onDashboard,
+  onProfile,
+  className = "",
+}: PageHeaderProps) {
+  return (
+    <header className={`site-header${className ? ` ${className}` : ""}`}>
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="page-title leading-tight">{title}</h1>
+          {subtitle && (
+            <p className="mt-1 page-subtitle hidden md:block">{subtitle}</p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 shrink-0">
+          {onProfile && (
+            <button onClick={onProfile} className="btn-primary">
+              Profile
+            </button>
+          )}
+          {onDashboard && (
+            <button onClick={onDashboard} className="btn-primary">
+              <span className="hidden md:inline">Dashboard</span>
+              <span className="md:hidden">Back</span>
+            </button>
+          )}
+          <button onClick={onLogout} className="btn-secondary">
+            Logout
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/components/ProgressBar.tsx
+++ b/frontend/components/ProgressBar.tsx
@@ -1,4 +1,5 @@
 // frontend/components/ProgressBar.tsx
+import { useState } from "react";
 import type { User } from "../lib/auth";
 
 /**
@@ -25,6 +26,10 @@ type ProgressBarProps = {
   user: User;
   /** Explicitly mark which step the user is currently on. */
   activeStep?: StepId;
+  /** Show a minimize/maximize toggle in the card header. */
+  collapsible?: boolean;
+  /** Force horizontal layout at sm+ (instead of going vertical again at lg+). */
+  horizontal?: boolean;
 };
 
 function buildSteps(user: User): Step[] {
@@ -37,83 +42,140 @@ function buildSteps(user: User): Step[] {
   })();
 
   return [
-    { id: "survey_pre",       label: "Pre-Quiz Survey",     abbr: "Survey",      completed: !!user.survey_pre_base_completed },
-    { id: "quiz_base",        label: "Base Quiz",           abbr: "Base Quiz",   completed: !!user.quiz_base_completed },
-    { id: "survey_post_base", label: "Mid Survey",          abbr: "Survey",      completed: !!user.survey_post_base_completed },
-    { id: "quiz_variant",     label: `${variantAbbr} Quiz`, abbr: variantAbbr,   completed: !!user.quiz_variant_completed },
-    { id: "survey_final",     label: "Final Survey",        abbr: "Survey",      completed: !!user.survey_post_variant_completed },
+    { id: "survey_pre",       label: "Pre-Quiz Survey",     abbr: "Survey",    completed: !!user.survey_pre_base_completed },
+    { id: "quiz_base",        label: "Base Quiz",           abbr: "Base Quiz", completed: !!user.quiz_base_completed },
+    { id: "survey_post_base", label: "Mid Survey",          abbr: "Survey",    completed: !!user.survey_post_base_completed },
+    { id: "quiz_variant",     label: `${variantAbbr} Quiz`, abbr: variantAbbr, completed: !!user.quiz_variant_completed },
+    { id: "survey_final",     label: "Final Survey",        abbr: "Survey",    completed: !!user.survey_post_variant_completed },
   ];
 }
 
-export default function ProgressBar({ user, activeStep }: ProgressBarProps) {
+function StepCircle({ step, index, isCurrent, isCompleted }: {
+  step: Step; index: number; isCurrent: boolean; isCompleted: boolean;
+}) {
+  return (
+    <div
+      className={[
+        "flex shrink-0 items-center justify-center rounded-full border-2 transition-colors font-semibold",
+        "h-8 w-8 text-xs",
+        isCurrent
+          ? "border-accent-600 bg-white text-accent-600 ring-[3px] ring-accent-600/25"
+          : isCompleted
+            ? "border-accent-600 bg-accent-600 text-white"
+            : "border-gray-300 bg-white text-gray-400",
+      ].join(" ")}
+    >
+      {isCompleted && !isCurrent ? (
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      ) : (
+        <span>{index + 1}</span>
+      )}
+    </div>
+  );
+}
+
+export default function ProgressBar({ user, activeStep, collapsible, horizontal }: ProgressBarProps) {
   const steps = buildSteps(user);
   const completedCount = steps.filter((s) => s.completed).length;
+  const [open, setOpen] = useState(true);
 
   return (
-    <div className="w-full rounded-xl border bg-white p-4 shadow-sm">
-      <div className="flex items-center justify-between mb-4">
+    <div className="w-full rounded-xl border bg-white shadow-sm">
+      {/* Card header — always visible */}
+      <div className={`flex items-center justify-between px-4 py-3 ${open ? "border-b border-gray-100" : ""}`}>
         <h3 className="text-sm font-semibold text-gray-700">Study Progress</h3>
-        <span className="text-xs text-gray-500">
-          {completedCount} of {steps.length} completed
-        </span>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-gray-500">{completedCount} of {steps.length} completed</span>
+          {collapsible && (
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-900 transition active:scale-95"
+              aria-label={open ? "Collapse progress" : "Expand progress"}
+            >
+              {open ? (
+                <>
+                  <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+                  </svg>
+                  Minimize
+                </>
+              ) : (
+                <>
+                  <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                  </svg>
+                  Expand
+                </>
+              )}
+            </button>
+          )}
+        </div>
       </div>
 
-      <div className="flex items-center">
-        {steps.map((step, i) => {
-          const isCompleted = step.completed;
-          const isCurrent = activeStep ? step.id === activeStep : false;
-
-          return (
-            <div key={step.id} className="flex items-center flex-1 last:flex-none">
-              <div className="flex flex-col items-center">
-                <div
-                  className={[
-                    "flex items-center justify-center rounded-full transition-colors",
-                    "h-7 w-7 sm:h-8 sm:w-8 border-2 text-xs sm:text-sm font-semibold",
-                    isCurrent
-                      ? "border-accent-600 bg-white text-accent-600 ring-[3px] ring-accent-600/25"
-                      : isCompleted
-                        ? "border-accent-600 bg-accent-600 text-white"
-                        : "border-gray-300 bg-white text-gray-400",
-                  ].join(" ")}
-                >
-                  {isCompleted && !isCurrent ? (
-                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
-                  ) : (
-                    <span>{i + 1}</span>
+      {open && (
+        <div className="px-4 pb-4 pt-3">
+          {/* Vertical: < sm always; lg+ only when not forced horizontal */}
+          <div className={`flex flex-col ${horizontal ? "sm:hidden" : "sm:hidden lg:flex"}`}>
+            {steps.map((step, i) => {
+              const isCompleted = step.completed;
+              const isCurrent = activeStep ? step.id === activeStep : false;
+              return (
+                <div key={step.id}>
+                  <div className="flex items-center gap-3">
+                    <StepCircle step={step} index={i} isCurrent={isCurrent} isCompleted={isCompleted} />
+                    <span className={[
+                      "text-sm leading-tight",
+                      isCurrent ? "text-accent-600 font-semibold"
+                        : isCompleted ? "text-accent-600 font-medium"
+                        : "text-gray-400",
+                    ].join(" ")}>
+                      {step.label}
+                    </span>
+                  </div>
+                  {i < steps.length - 1 && (
+                    <div className={[
+                      "ml-[15px] w-[2px] h-5 my-0.5",
+                      isCompleted ? "bg-accent-600" : "bg-gray-200",
+                    ].join(" ")} />
                   )}
                 </div>
+              );
+            })}
+          </div>
 
-                <span
-                  className={[
-                    "mt-1.5 text-center leading-tight whitespace-nowrap",
-                    "text-[0.6rem] sm:text-xs",
-                    isCurrent
-                      ? "text-accent-600 font-bold"
-                      : isCompleted
-                        ? "text-accent-600 font-medium"
+          {/* Horizontal: sm–lg normally; sm+ when forced horizontal */}
+          <div className={`hidden sm:flex items-center ${horizontal ? "" : "lg:hidden"}`}>
+            {steps.map((step, i) => {
+              const isCompleted = step.completed;
+              const isCurrent = activeStep ? step.id === activeStep : false;
+              return (
+                <div key={step.id} className="flex items-center flex-1 last:flex-none">
+                  <div className="flex flex-col items-center">
+                    <StepCircle step={step} index={i} isCurrent={isCurrent} isCompleted={isCompleted} />
+                    <span className={[
+                      "mt-1.5 text-center leading-tight whitespace-nowrap text-[0.6rem]",
+                      isCurrent ? "text-accent-600 font-bold"
+                        : isCompleted ? "text-accent-600 font-medium"
                         : "text-gray-400",
-                  ].join(" ")}
-                >
-                  <span className="hidden sm:inline">{step.label}</span>
-                  <span className="sm:hidden">{step.abbr}</span>
-                </span>
-              </div>
-
-              {i < steps.length - 1 && (
-                <div
-                  className={[
-                    "h-[2px] flex-1 mx-1 sm:mx-2",
-                    isCompleted ? "bg-accent-600" : "bg-gray-200",
-                  ].join(" ")}
-                />
-              )}
-            </div>
-          );
-        })}
-      </div>
+                    ].join(" ")}>
+                      {step.label}
+                    </span>
+                  </div>
+                  {i < steps.length - 1 && (
+                    <div className={[
+                      "h-[2px] flex-1 mx-1 mb-5",
+                      isCompleted ? "bg-accent-600" : "bg-gray-200",
+                    ].join(" ")} />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/ProgressBar.tsx
+++ b/frontend/components/ProgressBar.tsx
@@ -1,57 +1,23 @@
 // frontend/components/ProgressBar.tsx
 import { useState } from "react";
+import { buildStudySteps, type StudyStepId, type StudyStep } from "../lib/studySteps";
 import type { User } from "../lib/auth";
 
-/**
- * Step identifiers matching the actual user-visible study flow.
- * Demographics is excluded — always completed before these pages.
- *
- * Flow: Pre-Quiz Survey → Base Quiz → Post-Base Survey → Variant Quiz → Final Survey
- */
-export type StepId =
-  | "survey_pre"
-  | "quiz_base"
-  | "survey_post_base"
-  | "quiz_variant"
-  | "survey_final";
-
-type Step = {
-  id: StepId;
-  label: string;
-  abbr: string;
-  completed: boolean;
-};
+// Re-exported so existing imports of `StepId` from this file keep working.
+export type { StudyStepId as StepId };
 
 type ProgressBarProps = {
   user: User;
   /** Explicitly mark which step the user is currently on. */
-  activeStep?: StepId;
+  activeStep?: StudyStepId;
   /** Show a minimize/maximize toggle in the card header. */
   collapsible?: boolean;
   /** Force horizontal layout at sm+ (instead of going vertical again at lg+). */
   horizontal?: boolean;
 };
 
-function buildSteps(user: User): Step[] {
-  const variantAbbr = (() => {
-    const v = user.assigned_var;
-    if (v === "followup") return "Follow-Up";
-    if (v === "double") return "Dual";
-    if (v === "links") return "Links";
-    return "Variant";
-  })();
-
-  return [
-    { id: "survey_pre",       label: "Pre-Quiz Survey",     abbr: "Survey",    completed: !!user.survey_pre_base_completed },
-    { id: "quiz_base",        label: "Base Quiz",           abbr: "Base Quiz", completed: !!user.quiz_base_completed },
-    { id: "survey_post_base", label: "Mid Survey",          abbr: "Survey",    completed: !!user.survey_post_base_completed },
-    { id: "quiz_variant",     label: `${variantAbbr} Quiz`, abbr: variantAbbr, completed: !!user.quiz_variant_completed },
-    { id: "survey_final",     label: "Final Survey",        abbr: "Survey",    completed: !!user.survey_post_variant_completed },
-  ];
-}
-
 function StepCircle({ step, index, isCurrent, isCompleted }: {
-  step: Step; index: number; isCurrent: boolean; isCompleted: boolean;
+  step: StudyStep; index: number; isCurrent: boolean; isCompleted: boolean;
 }) {
   return (
     <div
@@ -77,7 +43,7 @@ function StepCircle({ step, index, isCurrent, isCompleted }: {
 }
 
 export default function ProgressBar({ user, activeStep, collapsible, horizontal }: ProgressBarProps) {
-  const steps = buildSteps(user);
+  const steps = buildStudySteps(user);
   const completedCount = steps.filter((s) => s.completed).length;
   const [open, setOpen] = useState(true);
 

--- a/frontend/components/ProgressBar.tsx
+++ b/frontend/components/ProgressBar.tsx
@@ -1,0 +1,119 @@
+// frontend/components/ProgressBar.tsx
+import type { User } from "../lib/auth";
+
+/**
+ * Step identifiers matching the actual user-visible study flow.
+ * Demographics is excluded — always completed before these pages.
+ *
+ * Flow: Pre-Quiz Survey → Base Quiz → Post-Base Survey → Variant Quiz → Final Survey
+ */
+export type StepId =
+  | "survey_pre"
+  | "quiz_base"
+  | "survey_post_base"
+  | "quiz_variant"
+  | "survey_final";
+
+type Step = {
+  id: StepId;
+  label: string;
+  abbr: string;
+  completed: boolean;
+};
+
+type ProgressBarProps = {
+  user: User;
+  /** Explicitly mark which step the user is currently on. */
+  activeStep?: StepId;
+};
+
+function buildSteps(user: User): Step[] {
+  const variantAbbr = (() => {
+    const v = user.assigned_var;
+    if (v === "followup") return "Follow-Up";
+    if (v === "double") return "Dual";
+    if (v === "links") return "Links";
+    return "Variant";
+  })();
+
+  return [
+    { id: "survey_pre",       label: "Pre-Quiz Survey",     abbr: "Survey",      completed: !!user.survey_pre_base_completed },
+    { id: "quiz_base",        label: "Base Quiz",           abbr: "Base Quiz",   completed: !!user.quiz_base_completed },
+    { id: "survey_post_base", label: "Mid Survey",          abbr: "Survey",      completed: !!user.survey_post_base_completed },
+    { id: "quiz_variant",     label: `${variantAbbr} Quiz`, abbr: variantAbbr,   completed: !!user.quiz_variant_completed },
+    { id: "survey_final",     label: "Final Survey",        abbr: "Survey",      completed: !!user.survey_post_variant_completed },
+  ];
+}
+
+export default function ProgressBar({ user, activeStep }: ProgressBarProps) {
+  const steps = buildSteps(user);
+  const completedCount = steps.filter((s) => s.completed).length;
+
+  return (
+    <div className="w-full rounded-xl border bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-gray-700">Study Progress</h3>
+        <span className="text-xs text-gray-500">
+          {completedCount} of {steps.length} completed
+        </span>
+      </div>
+
+      <div className="flex items-center">
+        {steps.map((step, i) => {
+          const isCompleted = step.completed;
+          const isCurrent = activeStep ? step.id === activeStep : false;
+
+          return (
+            <div key={step.id} className="flex items-center flex-1 last:flex-none">
+              <div className="flex flex-col items-center">
+                <div
+                  className={[
+                    "flex items-center justify-center rounded-full transition-colors",
+                    "h-7 w-7 sm:h-8 sm:w-8 border-2 text-xs sm:text-sm font-semibold",
+                    isCurrent
+                      ? "border-accent-600 bg-white text-accent-600 ring-[3px] ring-accent-600/25"
+                      : isCompleted
+                        ? "border-accent-600 bg-accent-600 text-white"
+                        : "border-gray-300 bg-white text-gray-400",
+                  ].join(" ")}
+                >
+                  {isCompleted && !isCurrent ? (
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  ) : (
+                    <span>{i + 1}</span>
+                  )}
+                </div>
+
+                <span
+                  className={[
+                    "mt-1.5 text-center leading-tight whitespace-nowrap",
+                    "text-[0.6rem] sm:text-xs",
+                    isCurrent
+                      ? "text-accent-600 font-bold"
+                      : isCompleted
+                        ? "text-accent-600 font-medium"
+                        : "text-gray-400",
+                  ].join(" ")}
+                >
+                  <span className="hidden sm:inline">{step.label}</span>
+                  <span className="sm:hidden">{step.abbr}</span>
+                </span>
+              </div>
+
+              {i < steps.length - 1 && (
+                <div
+                  className={[
+                    "h-[2px] flex-1 mx-1 sm:mx-2",
+                    isCompleted ? "bg-accent-600" : "bg-gray-200",
+                  ].join(" ")}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/QuestionBox.tsx
+++ b/frontend/components/QuestionBox.tsx
@@ -62,8 +62,8 @@ export default function QuestionBox({
               />
               <div
                 className={`cursor-pointer rounded-xl border px-4 py-3 transition-colors select-none
-                ${c.disabled ? "opacity-60 cursor-not-allowed" : "hover:border-blue-400"}
-                ${active ? "border-blue-600 bg-blue-50" : "border-gray-200 bg-white"}
+                ${c.disabled ? "opacity-60 cursor-not-allowed" : "hover:border-accent-400"}
+                ${active ? "border-accent-600 bg-accent-50" : "border-gray-200 bg-white"}
               `}
               >
                 <div className="font-medium text-gray-900"><span className="uppercase font-bold mr-2">{c.id}.</span>{c.label}</div>

--- a/frontend/components/QuestionBox.tsx
+++ b/frontend/components/QuestionBox.tsx
@@ -66,9 +66,9 @@ export default function QuestionBox({
                 ${active ? "border-accent-600 bg-accent-50" : "border-gray-200 bg-white"}
               `}
               >
-                <div className="font-medium text-gray-900"><span className="uppercase font-bold mr-2">{c.id}.</span>{c.label}</div>
+                <div className="text-lg font-medium text-gray-900"><span className="uppercase font-bold mr-2">{c.id}.</span>{c.label}</div>
                 {c.description && (
-                  <div className="text-sm text-gray-600 mt-0.5">{c.description}</div>
+                  <div className="text-base text-gray-600 mt-0.5">{c.description}</div>
                 )}
               </div>
             </label>

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -18,6 +18,7 @@ export type User = {
   consent?: boolean;
   consent_given_at?: string;
   is_admin: boolean;
+  assigned_var?: string | null;
   demographics_completed?: boolean;
   survey_pre_base_completed?: boolean;
   quiz_base_completed?: boolean;

--- a/frontend/lib/chat.ts
+++ b/frontend/lib/chat.ts
@@ -34,13 +34,21 @@ export async function sendChat(
   onToken?: (delta: string, agent?: string) => void,
   onDone?: (replies: string[], convId: string) => void,
   onFollowupToken?: (delta: string) => void,
+  answerIncorrectly?: boolean,
+  answerChoices?: { id: string; label: string }[],
 ): Promise<ChatResponse> {
   const resp = await fetch(`/api/chat/${quizId}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",
     signal,
-    body: JSON.stringify({ message, conversation_id: conversationId, agents }),
+    body: JSON.stringify({
+      message,
+      conversation_id: conversationId,
+      agents,
+      answer_incorrectly: answerIncorrectly ?? false,
+      answer_choices: (answerChoices ?? []).map((c) => ({ id: c.id, label: c.label })),
+    }),
   });
 
   if (!resp.ok) {

--- a/frontend/lib/quiz.ts
+++ b/frontend/lib/quiz.ts
@@ -14,6 +14,7 @@ export type QuizAttemptPublic = {
   status: "in_progress" | "completed" | string;
   total_questions: number;
   answered_count: number;
+  incorrect_question_ids: string[];
 };
 
 export type QuizStateResponse = {

--- a/frontend/lib/quizTheme.ts
+++ b/frontend/lib/quizTheme.ts
@@ -16,7 +16,7 @@ export const QUIZ_THEMES: Record<QuizType, QuizTheme> = {
     label: "Default",
     subtitle: "Default",
     description:
-      "A standard AI assistant that provides a single response to help you think through the question. No follow-up questions, no citations, just a clear explanation.",
+      "Standard AI assistant that provides answers to quiz questions.",
     dataTheme: "base",
   },
   followup: {
@@ -32,7 +32,7 @@ export const QUIZ_THEMES: Record<QuizType, QuizTheme> = {
     label: "Dual Response",
     subtitle: "Dual Response",
     description:
-      "Two independent AI agents (Agent A and Agent B) each provide their own response side by side, giving you two different perspectives on the question.",
+      "Two independent AI agents (Agent A and Agent B) each provide their own response side by side.",
     dataTheme: "double",
   },
   links: {
@@ -40,7 +40,7 @@ export const QUIZ_THEMES: Record<QuizType, QuizTheme> = {
     label: "Embedded Links",
     subtitle: "Embedded Links",
     description:
-      "The AI searches a knowledge base and embeds citation links directly in its response, so you can verify sources and explore further reading.",
+      "The AI searches online and embeds citation links directly in its response, so you can verify sources and explore further reading.",
     dataTheme: "links",
   },
 };

--- a/frontend/lib/quizTheme.ts
+++ b/frontend/lib/quizTheme.ts
@@ -32,7 +32,7 @@ export const QUIZ_THEMES: Record<QuizType, QuizTheme> = {
     label: "Dual Response",
     subtitle: "Dual Response",
     description:
-      "Two independent AI agents (Agent A and Agent B) each provide their own response side by side.",
+      "Two independent AI agents each provide their own response side by side.",
     dataTheme: "double",
   },
   links: {

--- a/frontend/lib/quizTheme.ts
+++ b/frontend/lib/quizTheme.ts
@@ -1,0 +1,53 @@
+// frontend/lib/quizTheme.ts
+
+export type QuizType = "base" | "followup" | "double" | "links";
+
+export type QuizTheme = {
+  id: QuizType;
+  label: string;
+  subtitle: string;
+  description: string;
+  dataTheme: QuizType;
+};
+
+export const QUIZ_THEMES: Record<QuizType, QuizTheme> = {
+  base: {
+    id: "base",
+    label: "Default",
+    subtitle: "Default",
+    description:
+      "A standard AI assistant that provides a single response to help you think through the question. No follow-up questions, no citations, just a clear explanation.",
+    dataTheme: "base",
+  },
+  followup: {
+    id: "followup",
+    label: "Follow-Up Questions",
+    subtitle: "Follow-Up Questions",
+    description:
+      "After responding to your message, the AI generates follow-up questions you can click to continue exploring the topic in more depth.",
+    dataTheme: "followup",
+  },
+  double: {
+    id: "double",
+    label: "Dual Response",
+    subtitle: "Dual Response",
+    description:
+      "Two independent AI agents (Agent A and Agent B) each provide their own response side by side, giving you two different perspectives on the question.",
+    dataTheme: "double",
+  },
+  links: {
+    id: "links",
+    label: "Embedded Links",
+    subtitle: "Embedded Links",
+    description:
+      "The AI searches a knowledge base and embeds citation links directly in its response, so you can verify sources and explore further reading.",
+    dataTheme: "links",
+  },
+};
+
+export function getQuizTheme(quizId: string): QuizTheme {
+  if (quizId in QUIZ_THEMES) {
+    return QUIZ_THEMES[quizId as QuizType];
+  }
+  return QUIZ_THEMES.base;
+}

--- a/frontend/lib/studySteps.ts
+++ b/frontend/lib/studySteps.ts
@@ -1,0 +1,152 @@
+// frontend/lib/studySteps.ts
+import type { User } from "./auth";
+
+// ── Survey stage types ──────────────────────────────────────────────────────
+
+export type SurveyStage = "pre_quiz" | "post_base" | "post_variant" | "complete";
+export type ActiveSurveyStage = Exclude<SurveyStage, "complete">;
+
+export function isActiveSurveyStage(value: unknown): value is ActiveSurveyStage {
+  return value === "pre_quiz" || value === "post_base" || value === "post_variant";
+}
+
+// ── Quiz ID types ───────────────────────────────────────────────────────────
+
+export const VARIANT_QUIZ_IDS = ["followup", "links", "double"] as const;
+export type VariantQuizId = (typeof VARIANT_QUIZ_IDS)[number];
+export type QuizId = "base" | VariantQuizId;
+
+export function isVariantQuizId(value: string): value is VariantQuizId {
+  return (VARIANT_QUIZ_IDS as readonly string[]).includes(value);
+}
+
+// ── Study step types ────────────────────────────────────────────────────────
+
+export type StudyStepId =
+  | "survey_pre"
+  | "quiz_base"
+  | "survey_post_base"
+  | "quiz_variant"
+  | "survey_final";
+
+export type StudyStep = {
+  id: StudyStepId;
+  label: string;
+  abbr: string;
+  path: string;
+  time: string;
+  kind: "quiz" | "survey";
+  subtitle: string;
+  completed: boolean;
+};
+
+// ── Subtitle strings (single source of truth for page headers + hero card) ──
+
+export const STEP_SUBTITLES: Record<StudyStepId, string> = {
+  survey_pre:       "Before you begin the base quiz, please answer a few quick questions.",
+  quiz_base:        "Answer each of the questions using the help of the AI assistant.",
+  survey_post_base: "You've completed the base quiz. Please answer a few follow-up questions.",
+  quiz_variant:     "Answer each of the questions using the help of the AI assistant.",
+  survey_final:     "You've completed the variant quiz. Please answer a few final questions.",
+};
+
+// ── Survey stage display config (titles, UI strings per stage) ───────────────
+
+export type StageConfig = {
+  title: string;
+  description: string;
+  emptyMessage: string;
+  submitLabel: string;
+  loadError: string;
+};
+
+export const STAGE_CONFIG: Record<ActiveSurveyStage, StageConfig> = {
+  pre_quiz: {
+    title: "Pre-Quiz Survey",
+    description: STEP_SUBTITLES.survey_pre,
+    emptyMessage: "No survey items found for the pre-quiz survey. Add items in the Surveys Panel.",
+    submitLabel: "Begin Base Quiz",
+    loadError: "Failed to load the pre-quiz survey.",
+  },
+  post_base: {
+    title: "Post-Base Quiz Survey",
+    description: STEP_SUBTITLES.survey_post_base,
+    emptyMessage: "No survey items found for the post-base survey. Add items in the Surveys Panel.",
+    submitLabel: "Continue to Variant Quiz",
+    loadError: "Failed to load the post-base survey.",
+  },
+  post_variant: {
+    title: "Final Survey",
+    description: STEP_SUBTITLES.survey_final,
+    emptyMessage: "No survey items found for the post-variant survey. Add items in the Surveys Panel.",
+    submitLabel: "Finish",
+    loadError: "Failed to load the final survey.",
+  },
+};
+
+// ── Step builder ─────────────────────────────────────────────────────────────
+
+export function buildStudySteps(user: User): StudyStep[] {
+  const v = user.assigned_var;
+  const variantAbbr =
+    v === "followup" ? "Follow-Up" :
+    v === "double"   ? "Dual"      :
+    v === "links"    ? "Links"     : "Variant";
+  const variantLabel =
+    v === "followup" ? "Follow-Up Questions Quiz" :
+    v === "double"   ? "Dual Agent Quiz"          :
+    v === "links"    ? "Embedded Links Quiz"      : "Variant Quiz";
+
+  return [
+    {
+      id: "survey_pre",
+      label: "Pre-Quiz Survey",
+      abbr: "Survey",
+      path: "/survey?stage=pre_quiz",
+      time: "5 min",
+      kind: "survey",
+      subtitle: STEP_SUBTITLES.survey_pre,
+      completed: !!user.survey_pre_base_completed,
+    },
+    {
+      id: "quiz_base",
+      label: "Base Quiz",
+      abbr: "Base Quiz",
+      path: "/quiz/base",
+      time: "10 min",
+      kind: "quiz",
+      subtitle: STEP_SUBTITLES.quiz_base,
+      completed: !!user.quiz_base_completed,
+    },
+    {
+      id: "survey_post_base",
+      label: "Mid Survey",
+      abbr: "Survey",
+      path: "/survey?stage=post_base",
+      time: "5 min",
+      kind: "survey",
+      subtitle: STEP_SUBTITLES.survey_post_base,
+      completed: !!user.survey_post_base_completed,
+    },
+    {
+      id: "quiz_variant",
+      label: variantLabel,
+      abbr: variantAbbr,
+      path: v ? `/quiz/${v}` : "",
+      time: "10 min",
+      kind: "quiz",
+      subtitle: STEP_SUBTITLES.quiz_variant,
+      completed: !!user.quiz_variant_completed,
+    },
+    {
+      id: "survey_final",
+      label: "Final Survey",
+      abbr: "Survey",
+      path: "/survey?stage=post_variant",
+      time: "5 min",
+      kind: "survey",
+      subtitle: STEP_SUBTITLES.survey_final,
+      completed: !!user.survey_post_variant_completed,
+    },
+  ];
+}

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { getMe, logout, type User } from "../lib/auth";
 import Link from "next/link";
+import PageHeader from "../components/PageHeader";
 
 
 export default function AdminPage() {
@@ -57,28 +58,12 @@ useEffect(() => {
     
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <header className="site-header">
-        <div className="site-header-inner">
-          <div>
-            <h1 className="page-title">Admin Panel</h1>
-            <p className="page-subtitle">Manage quiz questions and survey questions</p>
-          </div>
-          <div className="flex items-center gap-4">
-            <button
-              onClick={() => router.push("/dashboard")}
-              className="btn-primary"
-            >
-              Back to Dashboard
-            </button>
-            <button
-              onClick={onLogout}
-              className="btn-secondary"
-            >
-              Logout
-            </button>
-          </div>
-        </div>
-      </header>
+      <PageHeader
+        title="Admin Panel"
+        subtitle="Manage quiz questions and survey questions"
+        onDashboard={() => router.push("/dashboard")}
+        onLogout={onLogout}
+      />
 
       <div className="page-container">
         <div className="grid gap-4 sm:grid-cols-2">

--- a/frontend/pages/chat.tsx
+++ b/frontend/pages/chat.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import ChatBox from "../components/ChatBox";
 import { getMe, logout, type User } from "../lib/auth";
+import PageHeader from "../components/PageHeader";
 
 // Simple client-side guard. For stronger security, also check auth on the backend per request.
 export default function ChatPage() {
@@ -52,28 +53,12 @@ export default function ChatPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="site-header">
-        <div className="site-header-inner">
-          <div>
-            <h1 className="page-title">Chat</h1>
-            <p className="page-subtitle">Ask questions and interact with AI chatbot</p>
-          </div>
-          <div className="flex items-center gap-4">
-            <button
-              onClick={() => router.push("/dashboard")}
-              className="btn-primary"
-            >
-              Back to Dashboard
-            </button>
-            <button
-              onClick={onLogout}
-              className="btn-secondary"
-            >
-              Logout
-            </button>
-          </div>
-        </div>
-      </header>
+      <PageHeader
+        title="Chat"
+        subtitle="Ask questions and interact with AI chatbot"
+        onDashboard={() => router.push("/dashboard")}
+        onLogout={onLogout}
+      />
 
       <div className="page-container">
         <ChatBox quizId="default" />

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { getMe, logout, type User } from "../lib/auth";
 import ProgressBar from "../components/ProgressBar";
+import PageHeader from "../components/PageHeader";
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -46,28 +47,12 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="site-header">
-        <div className="flex items-center justify-between gap-4">
-          <div className="min-w-0">
-            <h1 className="page-title leading-tight">Dashboard</h1>
-          </div>
-
-          <div className="flex items-center gap-2 shrink-0">
-            <button
-              onClick={() => router.push("/profile")}
-              className="btn-primary"
-            >
-              Profile
-            </button>
-            <button
-              onClick={onLogout}
-              className="btn-secondary"
-            >
-              Logout
-            </button>
-          </div>
-        </div>
-      </header>
+      <PageHeader
+        title="Dashboard"
+        subtitle="Study progress overview."
+        onProfile={() => router.push("/profile")}
+        onLogout={onLogout}
+      />
 
       <div className="page-container">
         <div className="mb-4">

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -47,7 +47,7 @@ export default function DashboardPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="site-header">
-        <div className="max-w-6xl 2xl:max-w-screen-2xl mx-auto flex items-center justify-between gap-4">
+        <div className="flex items-center justify-between gap-4">
           <div className="min-w-0">
             <h1 className="page-title leading-tight">Dashboard</h1>
           </div>
@@ -71,7 +71,7 @@ export default function DashboardPage() {
 
       <div className="page-container">
         <div className="mb-4">
-          <ProgressBar user={user} />
+          <ProgressBar user={user} horizontal />
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { getMe, logout, type User } from "../lib/auth";
+import ProgressBar from "../components/ProgressBar";
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -46,12 +47,12 @@ export default function DashboardPage() {
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="site-header">
-        <div className="site-header-inner">
-          <div>
-            <h1 className="page-title">Dashboard</h1>
-            <p className="page-subtitle">Welcome to the dashboard, {user.email}</p>
+        <div className="max-w-6xl 2xl:max-w-screen-2xl mx-auto flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="page-title leading-tight">Dashboard</h1>
           </div>
-          <div className="flex items-center gap-4">
+
+          <div className="flex items-center gap-2 shrink-0">
             <button
               onClick={() => router.push("/profile")}
               className="btn-primary"
@@ -69,6 +70,10 @@ export default function DashboardPage() {
       </header>
 
       <div className="page-container">
+        <div className="mb-4">
+          <ProgressBar user={user} />
+        </div>
+
         <div className="grid gap-4 sm:grid-cols-2">
           {user?.is_admin && (
             <a

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { getMe, logout, type User } from "../lib/auth";
+import { buildStudySteps } from "../lib/studySteps";
 import ProgressBar from "../components/ProgressBar";
 import PageHeader from "../components/PageHeader";
 
@@ -14,13 +15,11 @@ export default function DashboardPage() {
     (async () => {
       try {
         const res = await getMe();
-        const u = res.user
-
+        const u = res.user;
         if (!cancelled && !u.demographics_completed) {
           router.replace("/demographics");
           return;
         }
-
         if (!cancelled) setUser(u);
       } catch {
         if (!cancelled) router.replace("/login");
@@ -45,6 +44,11 @@ export default function DashboardPage() {
     try { await logout(); } finally { router.replace("/login"); }
   }
 
+  const steps = buildStudySteps(user);
+  const nextStep = steps.find((s) => !s.completed && s.path);
+  const allComplete = steps.every((s) => s.completed);
+  const actionVerb = user.survey_pre_base_completed ? "Continue" : "Start";
+
   return (
     <div className="min-h-screen bg-gray-50">
       <PageHeader
@@ -54,80 +58,144 @@ export default function DashboardPage() {
         onLogout={onLogout}
       />
 
-      <div className="page-container">
-        <div className="mb-4">
-          <ProgressBar user={user} horizontal />
-        </div>
+      <div className="page-container flex flex-col gap-4">
+        <ProgressBar user={user} horizontal />
 
-        <div className="grid gap-4 sm:grid-cols-2">
-          {user?.is_admin && (
-            <a
-              href="/chat"
-              className="rounded-2xl border p-5 shadow-sm hover:shadow transition"
-            >
-              <h2 className="mb-1 text-lg 2xl:text-xl font-semibold">Chat</h2>
-              <p className="text-sm text-gray-600">
-                Ask questions and interact with AI chatbot
-              </p>
-            </a>
-          )}
-          
-          {user?.is_admin && (
-            <a
-              href="/playground"
-              className="rounded-2xl border p-5 shadow-sm hover:shadow transition"
-            >
-              <h2 className="mb-1 text-lg 2xl:text-xl font-semibold">Playground</h2>
-              <p className="text-sm text-gray-600">Sandbox to see how the different quiz styles look</p>
-            </a>
-          )}
+        {/* ── Next Step Hero Card ── */}
+        {allComplete ? (
+          <div className="w-full rounded-2xl border-2 border-blue-200 bg-blue-50 p-6 text-center shadow-sm">
+            <p className="text-xl font-semibold text-blue-800">Study Complete — thank you for participating!</p>
+          </div>
+        ) : nextStep ? (
+          <div className="w-full rounded-2xl border-2 border-blue-500 bg-white shadow-md overflow-hidden">
+            <div className="bg-blue-600 px-6 py-4">
+              <p className="text-xs font-semibold uppercase tracking-widest text-blue-200 mb-1">Next Step</p>
+              <h2 className="text-2xl font-bold text-white">{nextStep.label}</h2>
+              <p className="mt-1 text-sm text-blue-100">{nextStep.subtitle}</p>
+            </div>
+            <div className="px-6 py-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <div className="flex items-center gap-2 text-sm text-gray-500">
+                <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Estimated time: <span className="font-medium text-gray-700">{nextStep.time}</span>
+              </div>
+              <button
+                onClick={() => router.push(nextStep.path)}
+                className="w-full sm:w-auto rounded-xl bg-blue-600 px-8 py-3 text-base font-semibold text-white shadow hover:bg-blue-700 active:scale-[0.98] transition-all"
+              >
+                {actionVerb} the {nextStep.label}
+              </button>
+            </div>
+          </div>
+        ) : null}
 
-          {user?.is_admin && (
-            <a
-              href="/admin"
-              className="rounded-2xl border p-5 shadow-sm hover:shadow transition"
-            >
-              <h2 className="mb-1 text-lg 2xl:text-xl font-semibold">Admin Panel</h2>
-              <p className="text-sm text-gray-600">Manage questions and content</p>
-            </a>
-          )}
-          {/*Default quiz */}
-          <a
-            href="/quiz/base"
-            className="rounded-2xl border p-5 shadow-sm hover:shadow transition"
-          >
-            <h2 className="mb-1 text-lg 2xl:text-xl font-semibold">Quiz</h2>
-            <p className="text-sm text-gray-600">Begin the Quiz</p>
-          </a>
-          {/*Additional Quizzes below*/}
-          {user?.is_admin && (
-          <a
-            href="/quiz/double"
-            className="rounded-2xl border p-5 shadow-sm hover:shadow transition"
-          >
-            <h2 className="mb-1 text-lg 2xl:text-xl font-semibold">Dual Agent Quiz</h2>
-            <p className="text-sm text-gray-600">Begin the Quiz</p>
-          </a>
-          )}
-          {user?.is_admin && (
-          <a
-            href="/quiz/links"
-            className="rounded-2xl border p-5 shadow-sm hover:shadow transition"
-          >
-            <h2 className="mb-1 text-lg 2xl:text-xl font-semibold">Links Quiz</h2>
-            <p className="text-sm text-gray-600">Begin the Quiz</p>
-          </a>
-          )}
-          {user?.is_admin && (
-          <a
-            href="/quiz/followup"
-            className="rounded-2xl border p-5 shadow-sm hover:shadow transition"
-          >
-            <h2 className="mb-1 text-lg 2xl:text-xl font-semibold">Follow-up Questions Quiz</h2>
-            <p className="text-sm text-gray-600">Begin the Quiz</p>
-          </a>
-          )}
-        </div>
+        {/* ── Admin Section ── */}
+        {user.is_admin && (
+          <>
+            <div className="relative mt-2">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-300" />
+              </div>
+              <div className="relative flex justify-start">
+                <span className="bg-gray-50 pr-3 text-xs font-semibold uppercase tracking-widest text-gray-400">Admin</span>
+              </div>
+            </div>
+
+            {/* Tools */}
+            <div className="grid gap-4 sm:grid-cols-3">
+              {([
+                {
+                  href: "/chat",
+                  label: "Chat",
+                  desc: "Ask questions and interact with AI",
+                  icon: <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />,
+                },
+                {
+                  href: "/playground",
+                  label: "Playground",
+                  desc: "Preview and compare quiz styles",
+                  icon: <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />,
+                },
+                {
+                  href: "/admin",
+                  label: "Admin Panel",
+                  desc: "Manage questions and content",
+                  icon: <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z" />,
+                },
+              ] as const).map((tool) => (
+                <a key={tool.href} href={tool.href}
+                  className="group flex items-center gap-5 rounded-2xl border bg-white p-5 shadow-sm hover:border-blue-300 hover:shadow-md transition-all"
+                >
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 group-hover:bg-blue-100 transition-colors">
+                    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>{tool.icon}</svg>
+                  </div>
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900 leading-tight">{tool.label}</h2>
+                    <p className="text-sm text-gray-500 mt-0.5">{tool.desc}</p>
+                  </div>
+                </a>
+              ))}
+            </div>
+
+            {/* Study flow separator */}
+            <div className="relative mt-1">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-200" />
+              </div>
+              <div className="relative flex justify-start">
+                <span className="bg-gray-50 pr-3 text-xs font-medium uppercase tracking-widest text-gray-400">Study Flow</span>
+              </div>
+            </div>
+
+            {/* Quizzes */}
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {([
+                { href: "/quiz/base",     label: "Base Quiz",           theme: "base" },
+                { href: "/quiz/followup", label: "Follow-Up Questions", theme: "followup" },
+                { href: "/quiz/double",   label: "Dual Agent",          theme: "double" },
+                { href: "/quiz/links",    label: "Embedded Links",      theme: "links" },
+              ] as const).map((q) => (
+                <a key={q.href} href={q.href} data-quiz-theme={q.theme}
+                  className="group flex items-center gap-4 rounded-2xl border bg-white p-5 shadow-sm hover:border-accent-400 hover:shadow-md transition-all"
+                >
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-accent-50 text-accent-600 group-hover:bg-accent-100 transition-colors">
+                    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                    </svg>
+                  </div>
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900 leading-tight">{q.label}</h2>
+                    <p className="text-sm text-gray-500 mt-0.5">Quiz · 10 min</p>
+                  </div>
+                </a>
+              ))}
+            </div>
+
+            {/* Surveys */}
+            <div className="grid gap-4 sm:grid-cols-3">
+              {([
+                { href: "/survey?stage=pre_quiz",     label: "Pre-Quiz Survey", desc: "Before the base quiz · 5 min" },
+                { href: "/survey?stage=post_base",    label: "Mid Survey",      desc: "After the base quiz · 5 min" },
+                { href: "/survey?stage=post_variant", label: "Final Survey",    desc: "After the variant quiz · 5 min" },
+              ] as const).map((s) => (
+                <a key={s.href} href={s.href}
+                  className="group flex items-center gap-4 rounded-2xl border bg-white p-5 shadow-sm hover:border-blue-300 hover:shadow-md transition-all"
+                >
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-500 group-hover:bg-blue-100 transition-colors">
+                    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                  </div>
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900 leading-tight">{s.label}</h2>
+                    <p className="text-sm text-gray-500 mt-0.5">{s.desc}</p>
+                  </div>
+                </a>
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/pages/playground.tsx
+++ b/frontend/pages/playground.tsx
@@ -5,6 +5,7 @@ import ChatBox from "../components/ChatBox";
 import { getMe, logout, type User } from "../lib/auth";
 import { useRouter } from "next/router";
 import { apiFetch } from "../lib/fetcher";
+import PageHeader from "../components/PageHeader";
 
 export default function Playground() {
   const router = useRouter();
@@ -121,30 +122,12 @@ export default function Playground() {
 
   return (
     <div data-quiz-theme={active} className="min-h-screen bg-gray-50">
-      <header className="site-header">
-        <div className="site-header-inner">
-          <div>
-            <h1 className="page-title">Playground</h1>
-            <p className="page-subtitle">
-              Sandbox to see how the different quiz styles look
-            </p>
-          </div>
-          <div className="flex items-center gap-4">
-            <button
-              onClick={() => router.push("/dashboard")}
-              className="btn-primary"
-            >
-              Back to Dashboard
-            </button>
-            <button
-              onClick={onLogout}
-              className="btn-secondary"
-            >
-              Logout
-            </button>
-          </div>
-        </div>
-      </header>
+      <PageHeader
+        title="Playground"
+        subtitle="Sandbox to see how the different quiz styles look"
+        onDashboard={() => router.push("/dashboard")}
+        onLogout={onLogout}
+      />
 
       <div className="page-container">
         <section className="rounded-xl bg-white p-4 shadow-sm border">
@@ -155,7 +138,7 @@ export default function Playground() {
                 { id: "base",     activeClass: "bg-blue-600 text-white shadow-lg scale-105",   label: "Base Case" },
                 { id: "followup", activeClass: "bg-teal-600 text-white shadow-lg scale-105",   label: "Follow-up Question Case" },
                 { id: "double",   activeClass: "bg-violet-600 text-white shadow-lg scale-105", label: "Double Agent Case" },
-                { id: "links",    activeClass: "bg-amber-600 text-white shadow-lg scale-105",  label: "Embedded Links Case" },
+                { id: "links",    activeClass: "bg-red-600 text-white shadow-lg scale-105",  label: "Embedded Links Case" },
               ] as const).map((c) => (
                 <button
                   key={c.id}

--- a/frontend/pages/playground.tsx
+++ b/frontend/pages/playground.tsx
@@ -134,24 +134,20 @@ export default function Playground() {
           <h2 className="text-lg 2xl:text-xl font-medium mb-3">Case Selection</h2>
           <div className="space-y-4 max-w-3xl 2xl:max-w-none mx-auto">
             <div className="flex flex-wrap justify-center gap-3 mt-8">
-              {([
-                { id: "base",     activeClass: "bg-blue-600 text-white shadow-lg scale-105",   label: "Base Case" },
-                { id: "followup", activeClass: "bg-teal-600 text-white shadow-lg scale-105",   label: "Follow-up Question Case" },
-                { id: "double",   activeClass: "bg-violet-600 text-white shadow-lg scale-105", label: "Double Agent Case" },
-                { id: "links",    activeClass: "bg-red-600 text-white shadow-lg scale-105",  label: "Embedded Links Case" },
-              ] as const).map((c) => (
-                <button
-                  key={c.id}
-                  onClick={() => setActive(c.id)}
-                  aria-pressed={active === c.id}
-                  className={`px-6 py-3 rounded-xl font-semibold transition-all duration-300 shadow-md ${
-                    active === c.id
-                      ? c.activeClass
-                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                  }`}
-                >
-                  {c.label}
-                </button>
+              {(["base", "followup", "double", "links"] as const).map((id) => (
+                <div key={id} data-quiz-theme={id}>
+                  <button
+                    onClick={() => setActive(id)}
+                    aria-pressed={active === id}
+                    className={`px-6 py-3 rounded-xl font-semibold transition-all duration-300 shadow-md ${
+                      active === id
+                        ? "bg-accent-600 text-white shadow-lg scale-105"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                    }`}
+                  >
+                    {{ base: "Base Case", followup: "Follow-up Question Case", double: "Double Agent Case", links: "Embedded Links Case" }[id]}
+                  </button>
+                </div>
               ))}
             </div>
             <div className="p-6 bg-white rounded-xl shadow-inner">

--- a/frontend/pages/playground.tsx
+++ b/frontend/pages/playground.tsx
@@ -120,7 +120,7 @@ export default function Playground() {
   const atLast = currentIndex === questions.length - 1;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div data-quiz-theme={active} className="min-h-screen bg-gray-50">
       <header className="site-header">
         <div className="site-header-inner">
           <div>
@@ -151,50 +151,25 @@ export default function Playground() {
           <h2 className="text-lg 2xl:text-xl font-medium mb-3">Case Selection</h2>
           <div className="space-y-4 max-w-3xl 2xl:max-w-none mx-auto">
             <div className="flex flex-wrap justify-center gap-3 mt-8">
-              <button
-                onClick={() => setActive("base")}
-                aria-pressed={active === "base"}
-                className={`px-6 py-3 rounded-xl font-semibold transition-all duration-300 shadow-md ${
-                  active === "base"
-                    ? "bg-blue-600 text-white shadow-lg scale-105"
-                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                }`}
-              >
-                Base Case
-              </button>
-              <button
-                onClick={() => setActive("followup")}
-                aria-pressed={active === "followup"}
-                className={`px-6 py-3 rounded-xl font-semibold transition-all duration-300 shadow-md ${
-                  active === "followup"
-                    ? "bg-blue-600 text-white shadow-lg scale-105"
-                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                }`}
-              >
-                Follow-up Question Case
-              </button>
-              <button
-                onClick={() => setActive("double")}
-                aria-pressed={active === "double"}
-                className={`px-6 py-3 rounded-xl font-semibold transition-all duration-300 shadow-md ${
-                  active === "double"
-                    ? "bg-blue-600 text-white shadow-lg scale-105"
-                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                }`}
-              >
-                Double Agent Case
-              </button>
-              <button
-                onClick={() => setActive("links")}
-                aria-pressed={active === "links"}
-                className={`px-6 py-3 rounded-xl font-semibold transition-all duration-300 shadow-md ${
-                  active === "links"
-                    ? "bg-blue-600 text-white shadow-lg scale-105"
-                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                }`}
-              >
-                Embedded Links Case
-              </button>
+              {([
+                { id: "base",     activeClass: "bg-blue-600 text-white shadow-lg scale-105",   label: "Base Case" },
+                { id: "followup", activeClass: "bg-teal-600 text-white shadow-lg scale-105",   label: "Follow-up Question Case" },
+                { id: "double",   activeClass: "bg-violet-600 text-white shadow-lg scale-105", label: "Double Agent Case" },
+                { id: "links",    activeClass: "bg-amber-600 text-white shadow-lg scale-105",  label: "Embedded Links Case" },
+              ] as const).map((c) => (
+                <button
+                  key={c.id}
+                  onClick={() => setActive(c.id)}
+                  aria-pressed={active === c.id}
+                  className={`px-6 py-3 rounded-xl font-semibold transition-all duration-300 shadow-md ${
+                    active === c.id
+                      ? c.activeClass
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  }`}
+                >
+                  {c.label}
+                </button>
+              ))}
             </div>
             <div className="p-6 bg-white rounded-xl shadow-inner">
               {active === "base" && (
@@ -279,6 +254,7 @@ export default function Playground() {
           {/* Right column (Chat) */}
           <div className="h-[55vh] md:h-auto md:min-h-[500px] overflow-hidden">
             <ChatBox
+              key={active}
               quizId={active}
             />
           </div>
@@ -286,7 +262,7 @@ export default function Playground() {
 
         <div className="flex justify-between max-w-md mx-auto">
           <button
-            className="rounded-xl px-4 py-2 font-medium bg-blue-600 text-white disabled:opacity-60"
+            className="rounded-xl px-4 py-2 font-medium bg-accent-600 text-white disabled:opacity-60"
             onClick={() => setCurrentIndex((idx) => (idx > 0 ? idx - 1 : idx))}
             disabled={!hasQuestions || atFirst}
           >
@@ -298,7 +274,7 @@ export default function Playground() {
               : "No questions"}
           </span>
           <button
-            className="rounded-xl px-4 py-2 font-medium bg-blue-600 text-white disabled:opacity-60"
+            className="rounded-xl px-4 py-2 font-medium bg-accent-600 text-white disabled:opacity-60"
             onClick={() =>
               setCurrentIndex((idx) =>
                 idx < questions.length - 1 ? idx + 1 : idx,

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -101,22 +101,22 @@ export default function ProfilePage() {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <header className="bg-white border-b px-6 h-[8dvh] max-h-24 overflow-hidden overflow-hidden">
-        <div className="max-w-6xl mx-auto flex items-center justify-between h-full">
+      <header className="site-header">
+        <div className="flex items-center justify-between gap-4">
           <div>
-            <h1 className="text-2xl font-semibold text-gray-900">Profile</h1>
-            <p className="text-sm text-gray-600">Edit your user password</p>
+            <h1 className="page-title">Profile</h1>
+            <p className="page-subtitle hidden md:block">Edit your user password</p>
           </div>
           <div className="flex items-center gap-3">
-            <button 
+            <button
               onClick={() => router.push("/dashboard")}
-              className="text-sm px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition"
+              className="btn-primary"
             >
-              Back to Dashboard
+              Dashboard
             </button>
             <button
               onClick={onLogout}
-              className="text-sm px-4 py-2 rounded-lg bg-gray-100 hover:bg-gray-200 transition"
+              className="btn-secondary"
             >
               Logout
             </button>

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { getMe, logout, changePassword, type User } from "../lib/auth";
+import PageHeader from "../components/PageHeader";
 
 export default function ProfilePage() {
   const router = useRouter();
@@ -100,29 +101,12 @@ export default function ProfilePage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="site-header">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <h1 className="page-title">Profile</h1>
-            <p className="page-subtitle hidden md:block">Edit your user password</p>
-          </div>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => router.push("/dashboard")}
-              className="btn-primary"
-            >
-              Dashboard
-            </button>
-            <button
-              onClick={onLogout}
-              className="btn-secondary"
-            >
-              Logout
-            </button>
-          </div>
-        </div>
-      </header>
+      <PageHeader
+        title="Profile"
+        subtitle="Edit your user password"
+        onDashboard={() => router.push("/dashboard")}
+        onLogout={onLogout}
+      />
 
       {/* Main content */}
       <main className="max-w-xl mx-auto p-6">

--- a/frontend/pages/quiz/[quiz_id].tsx
+++ b/frontend/pages/quiz/[quiz_id].tsx
@@ -202,6 +202,9 @@ export default function QuizPage() {
   const attempt = quizState?.attempt;
   const conversationId = quizState?.conversation_id ?? null;
   const quizCompleted = attempt?.status === "completed";
+  const answerIncorrectly = Boolean(
+    current && attempt?.incorrect_question_ids?.includes(current.id),
+  );
 
   useEffect(() => {
     if (!current) return;
@@ -490,6 +493,8 @@ export default function QuizPage() {
                         onAssistantMessage={() => setFirstChatResponded(true)}
                         questionCollapsed={questionCollapsed}
                         onToggleQuestion={() => setQuestionCollapsed((c: boolean) => !c)}
+                        answerIncorrectly={answerIncorrectly}
+                        answerChoices={current?.choices}
                       />
                     </div>
                   )}

--- a/frontend/pages/quiz/[quiz_id].tsx
+++ b/frontend/pages/quiz/[quiz_id].tsx
@@ -326,38 +326,37 @@ export default function QuizPage() {
 
   return (
     <div data-quiz-theme={quizId ?? "base"} className="flex flex-col h-[100dvh] [@media(max-height:700px)]:h-auto bg-gray-50">
-      <header className="shrink-0 bg-white border-b px-4 py-2 sm:px-6 sm:py-3">
-        <div className="max-w-6xl 2xl:max-w-screen-2xl mx-auto flex items-center justify-between gap-4">
+      <header className="site-header shrink-0">
+        <div className="flex items-center justify-between gap-4">
           <div className="min-w-0">
             <h1 className="page-title leading-tight">
               {quizId ? quizId.charAt(0).toUpperCase() + quizId.slice(1) : ""} Quiz
               {quizCompleted ? (
-                <span className="ml-2 text-sm font-semibold text-green-700">(Done)</span>
+                <span className="ml-3 text-base font-semibold text-green-700">(Done)</span>
               ) : (
-                <span className="ml-2 text-sm md:text-base font-normal text-gray-400">
+                <span className="ml-3 text-base font-normal text-gray-400">
                   Step {quizId === "base" ? 2 : 4} of 5
                 </span>
               )}
             </h1>
-              {!quizCompleted && (
-              <p className="page-subtitle">
+            {!quizCompleted && (
+              <p className="page-subtitle hidden md:block">
                 Progress saved automatically.
               </p>
             )}
           </div>
-          
-          <div className="flex items-center gap-2 shrink-0">
+
+          <div className="flex items-center gap-3 shrink-0">
             <button
               onClick={() => router.replace("/dashboard")}
-              className="text-sm px-3 py-1.5 rounded-lg bg-accent-600 text-white hover:bg-accent-700 transition"
+              className="btn-primary"
             >
               <span className="hidden md:inline">Dashboard</span>
               <span className="md:hidden">Back</span>
             </button>
-
             <button
               onClick={onLogout}
-              className="text-sm px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 transition"
+              className="btn-secondary"
             >
               Logout
             </button>
@@ -366,7 +365,7 @@ export default function QuizPage() {
       </header>
 
       <div className="flex-1 min-h-0 md:overflow-auto [@media(max-height:700px)]:flex-none">
-        <div className="max-w-6xl 2xl:max-w-screen-2xl mx-auto px-3 py-2 md:px-6 md:py-6 h-full md:h-auto [@media(max-height:700px)]:h-auto">
+        <div className="px-3 py-2 md:px-6 md:py-6 h-full md:h-auto [@media(max-height:700px)]:h-auto">
           <div className="flex flex-col gap-2 md:gap-4 h-full md:h-auto [@media(max-height:700px)]:h-auto">
             {error && (
               <div className="text-sm text-red-600" role="alert">

--- a/frontend/pages/quiz/[quiz_id].tsx
+++ b/frontend/pages/quiz/[quiz_id].tsx
@@ -326,7 +326,8 @@ export default function QuizPage() {
   }
 
   return (
-    <div data-quiz-theme={quizId ?? "base"} className="flex flex-col h-[100dvh] bg-gray-50">
+      //Keep at page height on normal zoom levels but overflow and expand on very short viewports or when zoomed in, so the user can always access the whole quiz interface and see the quiz completion card without needing to scroll through the chat.
+    <div data-quiz-theme={quizId ?? "base"} className="flex h-[100dvh] flex-col overflow-hidden bg-gray-50 [@media(max-height:760px)]:h-auto [@media(max-height:760px)]:min-h-[100dvh] [@media(max-height:760px)]:overflow-visible">
       <PageHeader
         className="shrink-0"
         title={
@@ -346,9 +347,9 @@ export default function QuizPage() {
         onLogout={onLogout}
       />
 
-      <div className="flex-1 min-h-0 md:overflow-auto">
-        <div className="px-4 pt-2 sm:px-12 md:pt-6 md:pb-6 h-full md:h-auto">
-          <div className="flex flex-col gap-2 md:gap-4 h-full md:h-auto">
+      <div className="flex-1 min-h-0 overflow-hidden [@media(max-height:760px)]:flex-none [@media(max-height:760px)]:overflow-visible">
+        <div className="px-page py-2 md:py-6 h-full md:h-auto [@media(max-height:700px)]:h-auto">
+          <div className="flex flex-col gap-2 md:gap-4 h-full md:h-auto [@media(max-height:700px)]:h-auto">
             {error && (
               <div className="text-sm text-red-600" role="alert">
                 {error}
@@ -374,7 +375,7 @@ export default function QuizPage() {
                 />
               </div>
             ) : (
-              <div className="flex-1 min-h-0 md:flex-none flex flex-col md:grid min-w-0 md:grid-cols-[1fr_1.618fr] gap-3 md:gap-6">
+              <div className="flex-1 min-h-0 md:flex-none [@media(max-height:700px)]:flex-none flex flex-col md:grid min-w-0 md:grid-cols-[1fr_1.618fr] gap-3 md:gap-6">
                 <div className="shrink-0 flex flex-col gap-3 md:gap-6">
                   <section className="rounded-xl border bg-white shadow-sm">
                     {!quizState && (
@@ -466,7 +467,7 @@ export default function QuizPage() {
                   </section>
                 </div>
 
-                <div className="flex-1 min-h-0 md:flex-none min-w-0 md:self-start md:sticky md:top-0 md:h-[calc(100vh-9rem)]">
+                <div className="flex-1 min-h-0 md:flex-none [@media(max-height:700px)]:flex-none [@media(max-height:700px)]:min-h-[420px] min-w-0 md:self-start md:sticky md:top-0 md:h-[min(calc(100vh-9rem),80vw)]">
                   {quizId && (
                     <div className="h-full min-w-0 rounded-2xl overflow-hidden">
                       <ChatBox

--- a/frontend/pages/quiz/[quiz_id].tsx
+++ b/frontend/pages/quiz/[quiz_id].tsx
@@ -13,6 +13,7 @@ import {
 } from "../../lib/quiz";
 import ChatBox from "../../components/ChatBox";
 import QuizCompletionCard from "../../components/QuizCompletionCard";
+// ProgressBar is used on dashboard/survey; quiz page shows inline step count
 
 type SurveyStage = "pre_quiz" | "post_base" | "post_variant" | "complete";
 
@@ -324,39 +325,39 @@ export default function QuizPage() {
   }
 
   return (
-    <div className="flex flex-col h-[100dvh] [@media(max-height:700px)]:h-auto bg-gray-50">
-      <header className="shrink-0 bg-white border-b px-4 py-3 sm:px-6 sm:py-4">
-        <div className="site-header-inner">
-          <div>
-            <h1 className="page-title">
-              Quiz {quizId ?? rawQuizId}
-              {attempt && (
-                <span className="ml-3 text-base 2xl:text-lg font-normal text-gray-500">
-                  {attempt.answered_count} of {attempt.total_questions} answered
-                  {quizCompleted && (
-                    <span className="ml-2 font-semibold text-green-700">(Completed)</span>
-                  )}
+    <div data-quiz-theme={quizId ?? "base"} className="flex flex-col h-[100dvh] [@media(max-height:700px)]:h-auto bg-gray-50">
+      <header className="shrink-0 bg-white border-b px-4 py-2 sm:px-6 sm:py-3">
+        <div className="max-w-6xl 2xl:max-w-screen-2xl mx-auto flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="page-title leading-tight">
+              {quizId ? quizId.charAt(0).toUpperCase() + quizId.slice(1) : ""} Quiz
+              {quizCompleted ? (
+                <span className="ml-2 text-sm font-semibold text-green-700">(Done)</span>
+              ) : (
+                <span className="ml-2 text-sm md:text-base font-normal text-gray-400">
+                  Step {quizId === "base" ? 2 : 4} of 5
                 </span>
               )}
             </h1>
-            {!quizCompleted && (
+              {!quizCompleted && (
               <p className="page-subtitle">
-                Answer each question once. Your progress is saved automatically.
+                Progress saved automatically.
               </p>
             )}
           </div>
-
-          <div className="flex items-center gap-3">
+          
+          <div className="flex items-center gap-2 shrink-0">
             <button
               onClick={() => router.replace("/dashboard")}
-              className="text-sm px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition"
+              className="text-sm px-3 py-1.5 rounded-lg bg-accent-600 text-white hover:bg-accent-700 transition"
             >
-              Back to Dashboard
+              <span className="hidden md:inline">Dashboard</span>
+              <span className="md:hidden">Back</span>
             </button>
 
             <button
               onClick={onLogout}
-              className="text-sm px-3 py-1 rounded-lg bg-gray-100 hover:bg-gray-200 transition"
+              className="text-sm px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 transition"
             >
               Logout
             </button>
@@ -408,9 +409,16 @@ export default function QuizPage() {
                     {quizState && current && (
                       <>
                         <div className="p-4">
-                          <h2 className="text-xl 2xl:text-2xl font-semibold text-gray-900">
-                            Question {(attempt?.answered_count ?? 0) + 1} — {current.stem}
-                          </h2>
+                          <div className="flex items-baseline justify-between gap-3 mb-1">
+                            <h2 className="text-xl 2xl:text-2xl font-semibold text-gray-900">
+                              Question {(attempt?.answered_count ?? 0) + 1} - {current.stem}
+                            </h2>
+                            {attempt && (
+                              <span className="text-sm text-gray-400 whitespace-nowrap">
+                                {attempt.answered_count + 1} of {attempt.total_questions}
+                              </span>
+                            )}
+                          </div>
                         </div>
 
                         {current.subtitle && (
@@ -449,7 +457,7 @@ export default function QuizPage() {
                                   disabled={
                                     !selectedChoice || submitting || chatLoading
                                   }
-                                  className="rounded-lg px-4 py-2 bg-blue-600 text-white text-sm font-medium disabled:opacity-60"
+                                  className="rounded-lg px-4 py-2 bg-accent-600 text-white text-sm font-medium disabled:opacity-60"
                                 >
                                   {submitting ? "Submitting…" : "Submit answer"}
                                 </button>
@@ -466,7 +474,7 @@ export default function QuizPage() {
                                   <button
                                     type="button"
                                     onClick={onAskAssistantAboutQuestion}
-                                    className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition"
+                                    className="inline-flex items-center justify-center rounded-lg bg-accent-600 px-4 py-2 text-sm font-medium text-white hover:bg-accent-700 transition"
                                   >
                                     Ask the assistant about this question
                                   </button>

--- a/frontend/pages/quiz/[quiz_id].tsx
+++ b/frontend/pages/quiz/[quiz_id].tsx
@@ -13,6 +13,7 @@ import {
 } from "../../lib/quiz";
 import ChatBox from "../../components/ChatBox";
 import QuizCompletionCard from "../../components/QuizCompletionCard";
+import PageHeader from "../../components/PageHeader";
 // ProgressBar is used on dashboard/survey; quiz page shows inline step count
 
 type SurveyStage = "pre_quiz" | "post_base" | "post_variant" | "complete";
@@ -325,48 +326,29 @@ export default function QuizPage() {
   }
 
   return (
-    <div data-quiz-theme={quizId ?? "base"} className="flex flex-col h-[100dvh] [@media(max-height:700px)]:h-auto bg-gray-50">
-      <header className="site-header shrink-0">
-        <div className="flex items-center justify-between gap-4">
-          <div className="min-w-0">
-            <h1 className="page-title leading-tight">
-              {quizId ? quizId.charAt(0).toUpperCase() + quizId.slice(1) : ""} Quiz
-              {quizCompleted ? (
-                <span className="ml-3 text-base font-semibold text-green-700">(Done)</span>
-              ) : (
-                <span className="ml-3 text-base font-normal text-gray-400">
-                  Step {quizId === "base" ? 2 : 4} of 5
-                </span>
-              )}
-            </h1>
-            {!quizCompleted && (
-              <p className="page-subtitle hidden md:block">
-                Progress saved automatically.
-              </p>
+    <div data-quiz-theme={quizId ?? "base"} className="flex flex-col h-[100dvh] bg-gray-50">
+      <PageHeader
+        className="shrink-0"
+        title={
+          <>
+            {quizId ? quizId.charAt(0).toUpperCase() + quizId.slice(1) : ""} Quiz
+            {quizCompleted ? (
+              <span className="ml-3 text-base font-semibold text-green-700">(Done)</span>
+            ) : (
+              <span className="ml-3 text-base font-normal text-gray-400">
+                Step {quizId === "base" ? 2 : 4} of 5
+              </span>
             )}
-          </div>
+          </>
+        }
+        subtitle={!quizCompleted ? "Answer each of the questions using the help of the AI assistant." : undefined}
+        onDashboard={() => router.replace("/dashboard")}
+        onLogout={onLogout}
+      />
 
-          <div className="flex items-center gap-3 shrink-0">
-            <button
-              onClick={() => router.replace("/dashboard")}
-              className="btn-primary"
-            >
-              <span className="hidden md:inline">Dashboard</span>
-              <span className="md:hidden">Back</span>
-            </button>
-            <button
-              onClick={onLogout}
-              className="btn-secondary"
-            >
-              Logout
-            </button>
-          </div>
-        </div>
-      </header>
-
-      <div className="flex-1 min-h-0 md:overflow-auto [@media(max-height:700px)]:flex-none">
-        <div className="px-3 py-2 md:px-6 md:py-6 h-full md:h-auto [@media(max-height:700px)]:h-auto">
-          <div className="flex flex-col gap-2 md:gap-4 h-full md:h-auto [@media(max-height:700px)]:h-auto">
+      <div className="flex-1 min-h-0 md:overflow-auto">
+        <div className="px-4 pt-2 sm:px-12 md:pt-6 md:pb-6 h-full md:h-auto">
+          <div className="flex flex-col gap-2 md:gap-4 h-full md:h-auto">
             {error && (
               <div className="text-sm text-red-600" role="alert">
                 {error}
@@ -375,24 +357,24 @@ export default function QuizPage() {
 
             {quizCompleted ? (
               <div className="overflow-auto flex-1 min-h-0 md:flex-none">
-              <QuizCompletionCard
-                isAdmin={user.is_admin}
-                quizResults={quizResults}
-                onDashboard={() => router.replace("/dashboard")}
-                onNextStep={redirectAfterCompletion}
-                onReset={user.is_admin ? async () => {
-                  if (!quizId) return;
-                  await resetQuiz(quizId);
-                  invalidateMeCache();
-                  const state = await getQuizState(quizId);
-                  setQuizState(state);
-                  setSelectedChoice(null);
-                  setQuizResults(null);
-                } : undefined}
-              />
+                <QuizCompletionCard
+                  isAdmin={user.is_admin}
+                  quizResults={quizResults}
+                  onDashboard={() => router.replace("/dashboard")}
+                  onNextStep={redirectAfterCompletion}
+                  onReset={user.is_admin ? async () => {
+                    if (!quizId) return;
+                    await resetQuiz(quizId);
+                    invalidateMeCache();
+                    const state = await getQuizState(quizId);
+                    setQuizState(state);
+                    setSelectedChoice(null);
+                    setQuizResults(null);
+                  } : undefined}
+                />
               </div>
             ) : (
-              <div className="flex-1 min-h-0 md:flex-none [@media(max-height:700px)]:flex-none flex flex-col md:grid min-w-0 md:grid-cols-[1fr_1.618fr] gap-3 md:gap-6">
+              <div className="flex-1 min-h-0 md:flex-none flex flex-col md:grid min-w-0 md:grid-cols-[1fr_1.618fr] gap-3 md:gap-6">
                 <div className="shrink-0 flex flex-col gap-3 md:gap-6">
                   <section className="rounded-xl border bg-white shadow-sm">
                     {!quizState && (
@@ -409,11 +391,11 @@ export default function QuizPage() {
                       <>
                         <div className="p-4">
                           <div className="flex items-baseline justify-between gap-3 mb-1">
-                            <h2 className="text-xl 2xl:text-2xl font-semibold text-gray-900">
-                              Question {(attempt?.answered_count ?? 0) + 1} - {current.stem}
+                            <h2 className="text-2xl 2xl:text-3xl font-semibold text-gray-900">
+                              Question {(attempt?.answered_count ?? 0) + 1} — {current.stem}
                             </h2>
                             {attempt && (
-                              <span className="text-sm text-gray-400 whitespace-nowrap">
+                              <span className="text-base text-gray-400 whitespace-nowrap">
                                 {attempt.answered_count + 1} of {attempt.total_questions}
                               </span>
                             )}
@@ -421,72 +403,70 @@ export default function QuizPage() {
                         </div>
 
                         {current.subtitle && (
-                            <div className="px-4 pb-4">
-                              <p className="text-lg 2xl:text-xl text-gray-600">{current.subtitle}</p>
+                          <div className="px-4 pb-4">
+                            <p className="text-xl 2xl:text-2xl text-gray-600">{current.subtitle}</p>
+                          </div>
+                        )}
+
+                        <hr className="border-gray-200" />
+
+                        <div className={`relative p-4${questionCollapsed ? " hidden md:block" : ""}`}>
+                          <div
+                            className={`space-y-3 transition ${
+                              !hasAskedChat
+                                ? "pointer-events-none opacity-40 blur-[1px]"
+                                : ""
+                            }`}
+                          >
+                            <QuestionBox
+                              choices={current.choices as Choice[]}
+                              value={selectedChoice}
+                              onChange={setSelectedChoice}
+                              className="max-w-3xl 2xl:max-w-none mx-auto"
+                            />
+
+                            <div className="flex items-center justify-between gap-4 pt-2">
+                              <p className="text-base text-gray-600">
+                                Selected:{" "}
+                                <span className="font-semibold text-gray-900">
+                                  {selectedChoice?.toUpperCase() ?? "(none)"}
+                                </span>
+                              </p>
+
+                              <button
+                                onClick={onSubmit}
+                                disabled={!selectedChoice || submitting || chatLoading}
+                                className="btn-primary disabled:opacity-60 shrink-0"
+                              >
+                                {submitting ? "Submitting…" : "Submit answer"}
+                              </button>
                             </div>
-                          )}
+                          </div>
 
-                          <hr className="border-gray-200" />
-
-                          <div className={`relative p-4${questionCollapsed ? " hidden md:block" : ""}`}>
-                            <div
-                              className={`space-y-3 transition ${
-                                !hasAskedChat
-                                  ? "pointer-events-none opacity-40 blur-[1px]"
-                                  : ""
-                              }`}
-                            >
-                              <QuestionBox
-                                choices={current.choices as Choice[]}
-                                value={selectedChoice}
-                                onChange={setSelectedChoice}
-                                className="max-w-3xl 2xl:max-w-none mx-auto"
-                              />
-
-                              <div className="flex items-center justify-between text-sm text-gray-600 pt-1">
-                                <div>
-                                  Selected:{" "}
-                                  <span className="font-medium">
-                                    {selectedChoice?.toUpperCase() ?? "(none)"}
-                                  </span>
-                                </div>
-
+                          {!hasAskedChat && (
+                            <div className="absolute inset-0 flex items-center justify-center">
+                              <div className="rounded-xl bg-white/90 backdrop-blur shadow-md border px-6 py-4 text-center max-w-sm">
+                                <p className="text-sm text-gray-800 mb-3">
+                                  Before choosing an answer, send this question to
+                                  the assistant and read the explanation.
+                                </p>
                                 <button
-                                  onClick={onSubmit}
-                                  disabled={
-                                    !selectedChoice || submitting || chatLoading
-                                  }
-                                  className="rounded-lg px-4 py-2 bg-accent-600 text-white text-sm font-medium disabled:opacity-60"
+                                  type="button"
+                                  onClick={onAskAssistantAboutQuestion}
+                                  className="inline-flex items-center justify-center rounded-lg bg-accent-600 px-4 py-2 text-sm font-medium text-white hover:bg-accent-700 transition"
                                 >
-                                  {submitting ? "Submitting…" : "Submit answer"}
+                                  Ask the assistant about this question
                                 </button>
                               </div>
                             </div>
-
-                            {!hasAskedChat && (
-                              <div className="absolute inset-0 flex items-center justify-center">
-                                <div className="rounded-xl bg-white/90 backdrop-blur shadow-md border px-6 py-4 text-center max-w-sm">
-                                  <p className="text-sm text-gray-800 mb-3">
-                                    Before choosing an answer, send this question to
-                                    the assistant and read the explanation.
-                                  </p>
-                                  <button
-                                    type="button"
-                                    onClick={onAskAssistantAboutQuestion}
-                                    className="inline-flex items-center justify-center rounded-lg bg-accent-600 px-4 py-2 text-sm font-medium text-white hover:bg-accent-700 transition"
-                                  >
-                                    Ask the assistant about this question
-                                  </button>
-                                </div>
-                              </div>
-                            )}
-                          </div>
+                          )}
+                        </div>
                       </>
                     )}
                   </section>
                 </div>
 
-                <div className="flex-1 min-h-0 md:flex-none [@media(max-height:700px)]:flex-none [@media(max-height:700px)]:min-h-[420px] min-w-0 md:self-start md:sticky md:top-0 md:h-[min(calc(100vh-9rem),80vw)]">
+                <div className="flex-1 min-h-0 md:flex-none min-w-0 md:self-start md:sticky md:top-0 md:h-[calc(100vh-9rem)]">
                   {quizId && (
                     <div className="h-full min-w-0 rounded-2xl overflow-hidden">
                       <ChatBox

--- a/frontend/pages/quiz/[quiz_id].tsx
+++ b/frontend/pages/quiz/[quiz_id].tsx
@@ -14,41 +14,25 @@ import {
 import ChatBox from "../../components/ChatBox";
 import QuizCompletionCard from "../../components/QuizCompletionCard";
 import PageHeader from "../../components/PageHeader";
-// ProgressBar is used on dashboard/survey; quiz page shows inline step count
+import {
+  STEP_SUBTITLES,
+  isVariantQuizId,
+  type QuizId,
+} from "../../lib/studySteps";
 
-type SurveyStage = "pre_quiz" | "post_base" | "post_variant" | "complete";
-
-const VARIANT_QUIZ_IDS = ["followup", "links", "double"] as const;
-type VariantQuizId = (typeof VARIANT_QUIZ_IDS)[number];
-type QuizId = "base" | VariantQuizId;
-
-type ExtendedUser = User & {
-  assigned_var?: string | null;
-  survey_stage?: SurveyStage | null;
-  survey_pre_base_completed?: boolean;
-  quiz_base_completed?: boolean;
-  survey_post_base_completed?: boolean;
-  quiz_variant_completed?: boolean;
-  survey_post_variant_completed?: boolean;
-};
-
-function isVariantQuizId(value: string): value is VariantQuizId {
-  return (VARIANT_QUIZ_IDS as readonly string[]).includes(value);
-}
-
-function isValidQuizId(value: string, user?: ExtendedUser | null): boolean {
+function isValidQuizId(value: string, user?: User | null): boolean {
   if (user?.is_admin) return true;
   return value === "base" || isVariantQuizId(value);
 }
 
 function isUsersAssignedVariant(
   quizId: string,
-  user?: ExtendedUser | null,
+  user?: User | null,
 ): boolean {
   return Boolean(user?.assigned_var && quizId === user.assigned_var);
 }
 
-function canAccessQuiz(quizId: QuizId, user: ExtendedUser): boolean {
+function canAccessQuiz(quizId: QuizId, user: User): boolean {
   if (user.is_admin) {
     return true;
   }
@@ -64,7 +48,7 @@ function canAccessQuiz(quizId: QuizId, user: ExtendedUser): boolean {
   );
 }
 
-function getBlockedQuizRedirect(quizId: QuizId, user: ExtendedUser): string {
+function getBlockedQuizRedirect(quizId: QuizId, user: User): string {
   const assignedVariantPath = user.assigned_var
     ? `/quiz/${user.assigned_var}`
     : "/dashboard";
@@ -100,7 +84,7 @@ export default function QuizPage() {
   const router = useRouter();
   const rawQuizId = [router.query.quiz_id].flat()[0] ?? null;
 
-  const [user, setUser] = useState<ExtendedUser | null>(null);
+  const [user, setUser] = useState<User | null>(null);
   const [checking, setChecking] = useState(true);
 
   const [quizState, setQuizState] = useState<QuizStateResponse | null>(null);
@@ -132,7 +116,7 @@ export default function QuizPage() {
         const res = await getMe();
         if (cancel) return;
 
-        const u = res.user as ExtendedUser;
+        const u = res.user as User;
 
         if (!isValidQuizId(rawQuizId, u)) {
           router.replace("/dashboard");
@@ -223,7 +207,7 @@ export default function QuizPage() {
     try {
       invalidateMeCache();
       const res = await getMe();
-      const refreshedUser = res.user as ExtendedUser;
+      const refreshedUser = res.user as User;
 
       if (quizId === "base") {
         if (!refreshedUser.survey_post_base_completed) {
@@ -342,7 +326,7 @@ export default function QuizPage() {
             )}
           </>
         }
-        subtitle={!quizCompleted ? "Answer each of the questions using the help of the AI assistant." : undefined}
+        subtitle={!quizCompleted ? STEP_SUBTITLES[quizId === "base" ? "quiz_base" : "quiz_variant"] : undefined}
         onDashboard={() => router.replace("/dashboard")}
         onLogout={onLogout}
       />

--- a/frontend/pages/survey.tsx
+++ b/frontend/pages/survey.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import { getMe, invalidateMeCache, logout, type User } from "../lib/auth";
 import ProgressBar, { type StepId } from "../components/ProgressBar";
+import PageHeader from "../components/PageHeader";
 import {
   getSurveyState,
   submitSurvey,
@@ -65,14 +66,6 @@ const STAGE_CONFIG: Record<
   },
 };
 
-function isSurveyStage(value: unknown): value is SurveyStage {
-  return (
-    value === "pre_quiz" ||
-    value === "post_base" ||
-    value === "post_variant" ||
-    value === "complete"
-  );
-}
 
 function isActiveSurveyStage(value: unknown): value is ActiveSurveyStage {
   return (
@@ -178,10 +171,6 @@ export default function SurveyPage() {
     if (Array.isArray(value)) return value.length === 0;
     return false;
   }
-
-  const rawSurveyStage = isSurveyStage(user?.survey_stage)
-    ? user.survey_stage
-    : null;
 
   const forcedStage = isActiveSurveyStage(stage) ? stage : null;
 
@@ -416,37 +405,21 @@ export default function SurveyPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="site-header">
-        <div className="flex items-center justify-between gap-4">
-          <div className="min-w-0">
-            <h1 className="page-title leading-tight">
-              {config.title}
-              <span className="ml-3 text-base font-normal text-gray-400">
-                Step {surveyStepNum} of 5
-              </span>
-            </h1>
-            <p className="mt-1 page-subtitle hidden md:block">{config.description}</p>
-          </div>
+      <PageHeader
+        title={
+          <>
+            {config.title}
+            <span className="ml-3 text-base font-normal text-gray-400">
+              Step {surveyStepNum} of 5
+            </span>
+          </>
+        }
+        subtitle={config.description}
+        onDashboard={() => router.push("/dashboard")}
+        onLogout={onLogout}
+      />
 
-          <div className="flex items-center gap-3 shrink-0">
-            <button
-              onClick={() => router.push("/dashboard")}
-              className="btn-primary"
-            >
-              <span className="hidden md:inline">Dashboard</span>
-              <span className="md:hidden">Back</span>
-            </button>
-            <button
-              onClick={onLogout}
-              className="btn-secondary"
-            >
-              Logout
-            </button>
-          </div>
-        </div>
-      </header>
-
-      <main className="px-4 py-8 sm:px-8 sm:py-10">
+      <main className="px-4 py-8 sm:px-12 sm:py-10">
         <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[340px_1fr] lg:items-start lg:gap-12">
 
           {/* Sidebar */}

--- a/frontend/pages/survey.tsx
+++ b/frontend/pages/survey.tsx
@@ -351,22 +351,13 @@ export default function SurveyPage() {
     const right = item.scale_right_label ?? "Strongly agree";
 
     return (
-      <div className="space-y-2 rounded-lg border border-gray-200 bg-white p-4">
-        <p className="text-sm font-medium text-gray-900">
+      <div className="space-y-4 rounded-xl border border-gray-200 bg-white p-5 sm:p-6">
+        <p className="text-base font-medium text-gray-900 leading-snug">
           {item.prompt}
           {item.required && <span className="text-red-500"> *</span>}
         </p>
 
-        <div className="flex items-center justify-between text-xs text-gray-500">
-          <span>
-            {min} = {left}
-          </span>
-          <span>
-            {max} = {right}
-          </span>
-        </div>
-
-        <div className="mt-2 flex justify-between gap-2">
+        <div className="flex gap-2 sm:gap-3">
           {Array.from({ length: max - min + 1 }).map((_, idx) => {
             const n = min + idx;
             const checked = value === n;
@@ -375,14 +366,13 @@ export default function SurveyPage() {
               <label
                 key={n}
                 className={[
-                  "flex flex-1 cursor-pointer flex-col items-center rounded-md border px-2 py-2 text-xs transition",
+                  "flex flex-1 cursor-pointer flex-col items-center rounded-xl border-2 py-4 transition select-none",
                   checked
-                    ? "border-blue-500 bg-blue-50 text-blue-700 shadow-sm"
-                    : "border-gray-200 bg-gray-50 text-gray-700 hover:border-blue-300 hover:bg-blue-50/60",
+                    ? "border-blue-500 bg-blue-50 shadow-sm"
+                    : "border-gray-200 bg-white hover:border-blue-300 hover:bg-blue-50/50",
                 ].join(" ")}
               >
                 <input
-                  id={`${item.id}-${n}`}
                   type="radio"
                   name={item.id}
                   value={n}
@@ -390,10 +380,15 @@ export default function SurveyPage() {
                   onChange={() => setLikert(item.id, n)}
                   className="sr-only"
                 />
-                <span className="text-sm font-semibold">{n}</span>
+                <span className={`text-lg font-bold leading-none ${checked ? "text-blue-600" : "text-gray-500"}`}>{n}</span>
               </label>
             );
           })}
+        </div>
+
+        <div className="flex items-center justify-between text-sm text-gray-400">
+          <span>{left}</span>
+          <span>{right}</span>
         </div>
       </div>
     );
@@ -417,29 +412,33 @@ export default function SurveyPage() {
     return undefined;
   })();
 
+  const surveyStepNum = activeSurveyStage === "pre_quiz" ? 1 : activeSurveyStage === "post_base" ? 3 : 5;
+
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="border-b bg-white px-4 py-2 sm:px-6 sm:py-3">
-        <div className="mx-auto flex max-w-6xl 2xl:max-w-screen-2xl items-center justify-between gap-4">
+      <header className="site-header">
+        <div className="flex items-center justify-between gap-4">
           <div className="min-w-0">
-            <h1 className="page-title leading-tight">{config.title}</h1>
-            <p className="text-xs md:text-sm text-gray-500 leading-tight">
-              <span className="hidden md:inline">{config.description}</span>
-              <span className="md:hidden">Complete all required questions.</span>
-            </p>
+            <h1 className="page-title leading-tight">
+              {config.title}
+              <span className="ml-3 text-base font-normal text-gray-400">
+                Step {surveyStepNum} of 5
+              </span>
+            </h1>
+            <p className="mt-1 page-subtitle hidden md:block">{config.description}</p>
           </div>
 
-          <div className="flex items-center gap-2 shrink-0">
+          <div className="flex items-center gap-3 shrink-0">
             <button
               onClick={() => router.push("/dashboard")}
-              className="text-sm px-3 py-1.5 rounded-lg bg-blue-600 text-white transition hover:bg-blue-700"
+              className="btn-primary"
             >
               <span className="hidden md:inline">Dashboard</span>
               <span className="md:hidden">Back</span>
             </button>
             <button
               onClick={onLogout}
-              className="text-sm px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 transition"
+              className="btn-secondary"
             >
               Logout
             </button>
@@ -447,60 +446,67 @@ export default function SurveyPage() {
         </div>
       </header>
 
-      <main className="mx-auto max-w-3xl p-6">
-        <div className="mb-6">
-          <ProgressBar user={user} activeStep={surveyStepId} />
-        </div>
-        <form
-          onSubmit={onSubmit}
-          className="space-y-6 rounded-xl border bg-white p-6 shadow-sm"
-        >
-          {error && (
-            <div className="text-sm text-red-600" role="alert">
-              {error}
-            </div>
-          )}
+      <main className="px-4 py-8 sm:px-8 sm:py-10">
+        <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[340px_1fr] lg:items-start lg:gap-12">
 
-          {loadingSurvey ? (
-            <div className="text-sm text-gray-500">Loading survey…</div>
-          ) : items.length === 0 ? (
-            <div className="text-sm text-gray-500">{config.emptyMessage}</div>
-          ) : (
-            <>
-              {items.map((item) =>
-                item.type === "likert" ? (
-                  <div key={item.id}>{renderLikertRow(item)}</div>
-                ) : (
-                  <div
-                    key={item.id}
-                    className="rounded-lg border border-gray-200 bg-white p-4"
-                  >
-                    <p className="text-sm font-medium text-gray-900">
-                      {item.prompt}
-                      {item.required && (
-                        <span className="text-red-500"> *</span>
-                      )}
-                    </p>
-                    <p className="mt-2 text-xs text-gray-500">
-                      Unsupported question type:{" "}
-                      <span className="font-medium">{item.type}</span>
-                    </p>
-                  </div>
-                ),
-              )}
+          {/* Sidebar */}
+          <aside className="lg:sticky lg:top-6">
+            <ProgressBar user={user} activeStep={surveyStepId} collapsible />
+          </aside>
 
-              <div className="flex justify-end pt-2">
-                <button
-                  type="submit"
-                  disabled={saving}
-                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
-                >
-                  {saving ? "Saving…" : config.submitLabel}
-                </button>
+          {/* Form */}
+          <form
+            onSubmit={onSubmit}
+            className="space-y-6 rounded-xl border bg-white p-8 shadow-sm"
+          >
+            {error && (
+              <div className="text-sm text-red-600" role="alert">
+                {error}
               </div>
-            </>
-          )}
-        </form>
+            )}
+
+            {loadingSurvey ? (
+              <div className="text-sm text-gray-500">Loading survey…</div>
+            ) : items.length === 0 ? (
+              <div className="text-sm text-gray-500">{config.emptyMessage}</div>
+            ) : (
+              <>
+                {items.map((item) =>
+                  item.type === "likert" ? (
+                    <div key={item.id}>{renderLikertRow(item)}</div>
+                  ) : (
+                    <div
+                      key={item.id}
+                      className="rounded-xl border border-gray-200 bg-white p-5 sm:p-6"
+                    >
+                      <p className="text-base font-medium text-gray-900 leading-snug">
+                        {item.prompt}
+                        {item.required && (
+                          <span className="text-red-500"> *</span>
+                        )}
+                      </p>
+                      <p className="mt-2 text-sm text-gray-500">
+                        Unsupported question type:{" "}
+                        <span className="font-medium">{item.type}</span>
+                      </p>
+                    </div>
+                  ),
+                )}
+
+                <div className="flex justify-end pt-4">
+                  <button
+                    type="submit"
+                    disabled={saving}
+                    className="rounded-xl bg-blue-600 px-8 py-3 text-base font-semibold text-white hover:bg-blue-700 disabled:opacity-60 transition"
+                  >
+                    {saving ? "Saving…" : config.submitLabel}
+                  </button>
+                </div>
+              </>
+            )}
+          </form>
+
+        </div>
       </main>
     </div>
   );

--- a/frontend/pages/survey.tsx
+++ b/frontend/pages/survey.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import { getMe, invalidateMeCache, logout, type User } from "../lib/auth";
+import ProgressBar, { type StepId } from "../components/ProgressBar";
 import {
   getSurveyState,
   submitSurvey,
@@ -409,27 +410,36 @@ export default function SurveyPage() {
   if (!user) return null;
   if (!activeSurveyStage || !config) return null;
 
+  const surveyStepId: StepId | undefined = (() => {
+    if (activeSurveyStage === "pre_quiz") return "survey_pre";
+    if (activeSurveyStage === "post_base") return "survey_post_base";
+    if (activeSurveyStage === "post_variant") return "survey_final";
+    return undefined;
+  })();
+
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="border-b bg-white px-6 h-[8dvh] max-h-24 overflow-hidden overflow-hidden">
-        <div className="mx-auto flex max-w-6xl items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold text-gray-900">
-              {config.title}
-            </h1>
-            <p className="text-sm text-gray-600">{config.description}</p>
+      <header className="border-b bg-white px-4 py-2 sm:px-6 sm:py-3">
+        <div className="mx-auto flex max-w-6xl 2xl:max-w-screen-2xl items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="page-title leading-tight">{config.title}</h1>
+            <p className="text-xs md:text-sm text-gray-500 leading-tight">
+              <span className="hidden md:inline">{config.description}</span>
+              <span className="md:hidden">Complete all required questions.</span>
+            </p>
           </div>
 
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 shrink-0">
             <button
               onClick={() => router.push("/dashboard")}
-              className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white transition hover:bg-blue-700"
+              className="text-sm px-3 py-1.5 rounded-lg bg-blue-600 text-white transition hover:bg-blue-700"
             >
-              Back to Dashboard
+              <span className="hidden md:inline">Dashboard</span>
+              <span className="md:hidden">Back</span>
             </button>
             <button
               onClick={onLogout}
-              className="rounded-lg bg-gray-100 px-4 py-2 text-sm hover:bg-gray-200"
+              className="text-sm px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 transition"
             >
               Logout
             </button>
@@ -438,6 +448,9 @@ export default function SurveyPage() {
       </header>
 
       <main className="mx-auto max-w-3xl p-6">
+        <div className="mb-6">
+          <ProgressBar user={user} activeStep={surveyStepId} />
+        </div>
         <form
           onSubmit={onSubmit}
           className="space-y-6 rounded-xl border bg-white p-6 shadow-sm"

--- a/frontend/pages/survey.tsx
+++ b/frontend/pages/survey.tsx
@@ -2,8 +2,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import { getMe, invalidateMeCache, logout, type User } from "../lib/auth";
-import ProgressBar, { type StepId } from "../components/ProgressBar";
+import ProgressBar from "../components/ProgressBar";
 import PageHeader from "../components/PageHeader";
+import {
+  STAGE_CONFIG,
+  isActiveSurveyStage,
+  type ActiveSurveyStage,
+  type StudyStepId,
+} from "../lib/studySteps";
 import {
   getSurveyState,
   submitSurvey,
@@ -11,74 +17,12 @@ import {
   type SurveyAnswer,
 } from "../lib/surveys";
 
-type SurveyStage = "pre_quiz" | "post_base" | "post_variant" | "complete";
-
-type ActiveSurveyStage = Exclude<SurveyStage, "complete">;
-
-type ExtendedUser = User & {
-  assigned_var?: string | null;
-  survey_stage?: SurveyStage | null;
-  survey_pre_base_completed?: boolean;
-  survey_post_base_completed?: boolean;
-  survey_post_variant_completed?: boolean;
-  quiz_base_completed?: boolean;
-  quiz_variant_completed?: boolean;
-};
-
-const STAGE_CONFIG: Record<
-  ActiveSurveyStage,
-  {
-    title: string;
-    description: string;
-    emptyMessage: string;
-    submitLabel: string;
-    loadError: string;
-  }
-> = {
-  pre_quiz: {
-    title: "Pre-Quiz Survey",
-    description:
-      "Before you begin the base quiz, please answer a few quick questions.",
-    emptyMessage:
-      "No survey items found for the pre-quiz survey. Add items in the Surveys Panel.",
-    submitLabel: "Begin Base Quiz",
-    loadError: "Failed to load the pre-quiz survey.",
-  },
-
-  post_base: {
-    title: "Post-Base Quiz Survey",
-    description:
-      "You’ve completed the base quiz. Please answer a few follow-up questions.",
-    emptyMessage:
-      "No survey items found for the post-base survey. Add items in the Surveys Panel.",
-    submitLabel: "Continue to Variant Quiz",
-    loadError: "Failed to load the post-base survey.",
-  },
-
-  post_variant: {
-    title: "Final Survey",
-    description:
-      "You’ve completed the variant quiz. Please answer a few final questions.",
-    emptyMessage:
-      "No survey items found for the post-variant survey. Add items in the Surveys Panel.",
-    submitLabel: "Finish",
-    loadError: "Failed to load the final survey.",
-  },
-};
-
-
-function isActiveSurveyStage(value: unknown): value is ActiveSurveyStage {
-  return (
-    value === "pre_quiz" || value === "post_base" || value === "post_variant"
-  );
-}
-
 /**
  * Returns the survey stage that should actually be shown right now.
  * Returns null when the user should not see a survey page and should be routed onward.
  */
 function resolveCurrentSurveyStage(
-  user: ExtendedUser | null,
+  user: User | null,
 ): ActiveSurveyStage | null {
   if (!user) return null;
 
@@ -113,7 +57,7 @@ function getLoadStage(activeStage: ActiveSurveyStage): ActiveSurveyStage {
  * When there is no active survey to show, decide where the user should go next.
  */
 function getNextRouteForResolvedGap(
-  user: ExtendedUser | null,
+  user: User | null,
   quizId?: string,
 ): string {
   if (!user) return "/dashboard";
@@ -148,7 +92,7 @@ export default function SurveyPage() {
     stage?: string;
   };
 
-  const [user, setUser] = useState<ExtendedUser | null>(null);
+  const [user, setUser] = useState<User | null>(null);
   const [checking, setChecking] = useState(true);
 
   const [saving, setSaving] = useState(false);
@@ -186,7 +130,7 @@ export default function SurveyPage() {
         const res = await getMe();
         if (cancel) return;
 
-        setUser(res.user as ExtendedUser);
+        setUser(res.user as User);
       } catch {
         if (!cancel) router.replace("/login");
       } finally {
@@ -243,7 +187,7 @@ export default function SurveyPage() {
           const refreshed = await getMe();
           if (cancel) return;
           router.replace(
-            getNextRouteForResolvedGap(refreshed.user as ExtendedUser, quiz_id),
+            getNextRouteForResolvedGap(refreshed.user as User, quiz_id),
           );
           return;
         }
@@ -305,7 +249,7 @@ export default function SurveyPage() {
       await submitSurvey(activeSurveyStage, answers);
       invalidateMeCache();
 
-      const optimisticUser: ExtendedUser | null =
+      const optimisticUser: User | null =
         user &&
         ({
           ...user,
@@ -321,7 +265,7 @@ export default function SurveyPage() {
             activeSurveyStage === "post_variant"
               ? true
               : user.survey_post_variant_completed,
-        } as ExtendedUser);
+        } as User);
 
       router.replace(getNextRouteForResolvedGap(optimisticUser, quiz_id));
     } catch (e) {
@@ -394,7 +338,7 @@ export default function SurveyPage() {
   if (!user) return null;
   if (!activeSurveyStage || !config) return null;
 
-  const surveyStepId: StepId | undefined = (() => {
+  const surveyStepId: StudyStepId | undefined = (() => {
     if (activeSurveyStage === "pre_quiz") return "survey_pre";
     if (activeSurveyStage === "post_base") return "survey_post_base";
     if (activeSurveyStage === "post_variant") return "survey_final";

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -48,12 +48,12 @@ body {
 }
 
 [data-quiz-theme="links"] {
---accent-50:  255 253 230;   /* cream yellow */
---accent-100: 255 247 180;   /* pale lemon */
---accent-400: 255 215 64;    /* vibrant lemon */
---accent-500: 245 190 35;    /* golden lemon */
---accent-600: 214 145 20;    /* warm gold */
---accent-700: 166 105 10;    /* deep gold */
+--accent-50:  248 250 252;   /* slate-50  */
+--accent-100: 241 245 249;   /* slate-100 */
+--accent-400: 148 163 184;   /* slate-400 */
+--accent-500: 100 116 139;   /* slate-500 */
+--accent-600: 71 85 105;     /* slate-600 */
+--accent-700: 51 65 85;      /* slate-700 */
 }
 
 @layer components {

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -57,9 +57,9 @@ body {
 }
 
 @layer components {
-  /* Sticky page header — used by standard scroll-layout pages */
+  /* Sticky page header — used by all study pages */
   .site-header {
-    @apply sticky top-0 z-10 bg-white border-b px-4 py-3 sm:px-6 sm:py-4;
+    @apply sticky top-0 z-10 bg-white border-b px-4 py-4 sm:px-8 sm:py-5;
   }
 
   /* Header inner row — title + buttons, wraps on small screens */
@@ -70,17 +70,17 @@ body {
 
   /* Standard page content container */
   .page-container {
-    @apply max-w-6xl 2xl:max-w-screen-2xl mx-auto px-3 py-4 sm:px-6 sm:py-6;
+    @apply px-4 py-6 sm:px-8 sm:py-8;
   }
 
   /* Page-level h1 */
   .page-title {
-    @apply text-xl sm:text-2xl 2xl:text-3xl font-semibold text-gray-900;
+    @apply text-2xl sm:text-3xl 2xl:text-4xl font-semibold text-gray-900;
   }
 
   /* Page-level subtitle / description */
   .page-subtitle {
-    @apply text-sm 2xl:text-base text-gray-600;
+    @apply text-base 2xl:text-lg text-gray-600;
   }
 
   /* Card / section surface */
@@ -91,11 +91,11 @@ body {
   /* Primary action button — uses quiz accent color */
   .btn-primary {
     @apply bg-accent-600 text-white hover:bg-accent-700 transition
-           rounded-lg px-4 py-2 text-sm font-medium;
+           rounded-lg px-6 py-3 text-base font-semibold;
   }
 
   /* Secondary / ghost button */
   .btn-secondary {
-    @apply bg-gray-100 hover:bg-gray-200 transition rounded-lg px-4 py-2 text-sm;
+    @apply bg-gray-100 hover:bg-gray-200 transition rounded-lg px-6 py-3 text-base font-medium;
   }
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -48,18 +48,18 @@ body {
 }
 
 [data-quiz-theme="links"] {
-  --accent-50:  255 251 235;   /* amber-50  */
-  --accent-100: 254 243 199;   /* amber-100 */
-  --accent-400: 251 191 36;    /* amber-400 */
-  --accent-500: 245 158 11;    /* amber-500 */
-  --accent-600: 217 119 6;     /* amber-600 */
-  --accent-700: 180 83 9;      /* amber-700 */
+--accent-50:  255 253 230;   /* cream yellow */
+--accent-100: 255 247 180;   /* pale lemon */
+--accent-400: 255 215 64;    /* vibrant lemon */
+--accent-500: 245 190 35;    /* golden lemon */
+--accent-600: 214 145 20;    /* warm gold */
+--accent-700: 166 105 10;    /* deep gold */
 }
 
 @layer components {
   /* Sticky page header — used by all study pages */
   .site-header {
-    @apply sticky top-0 z-10 bg-white border-b px-4 py-4 sm:px-8 sm:py-5;
+    @apply sticky top-0 z-10 bg-white border-b px-4 py-3 sm:px-12 sm:py-4;
   }
 
   /* Header inner row — title + buttons, wraps on small screens */
@@ -70,17 +70,17 @@ body {
 
   /* Standard page content container */
   .page-container {
-    @apply px-4 py-6 sm:px-8 sm:py-8;
+    @apply px-4 py-6 sm:px-12 sm:py-8;
   }
 
   /* Page-level h1 */
   .page-title {
-    @apply text-2xl sm:text-3xl 2xl:text-4xl font-semibold text-gray-900;
+    @apply text-xl sm:text-2xl 2xl:text-3xl font-semibold text-gray-900;
   }
 
   /* Page-level subtitle / description */
   .page-subtitle {
-    @apply text-base 2xl:text-lg text-gray-600;
+    @apply text-sm sm:text-base 2xl:text-lg text-gray-600;
   }
 
   /* Card / section surface */

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -14,6 +14,48 @@ body {
   @apply bg-gray-50 text-gray-900;
 }
 
+/* ── Quiz-type accent color palettes ──
+   Each quiz type gets its own set of accent CSS variables,
+   scoped via the data-quiz-theme attribute.
+   Values are space-separated RGB channels for Tailwind alpha support. */
+
+:root,
+[data-quiz-theme="base"] {
+  --accent-50:  239 246 255;   /* blue-50   */
+  --accent-100: 219 234 254;   /* blue-100  */
+  --accent-400: 96 165 250;    /* blue-400  */
+  --accent-500: 59 130 246;    /* blue-500  */
+  --accent-600: 37 99 235;     /* blue-600  */
+  --accent-700: 29 78 216;     /* blue-700  */
+}
+
+[data-quiz-theme="followup"] {
+  --accent-50:  240 253 250;   /* teal-50   */
+  --accent-100: 204 251 241;   /* teal-100  */
+  --accent-400: 45 212 191;    /* teal-400  */
+  --accent-500: 20 184 166;    /* teal-500  */
+  --accent-600: 13 148 136;    /* teal-600  */
+  --accent-700: 15 118 110;    /* teal-700  */
+}
+
+[data-quiz-theme="double"] {
+  --accent-50:  245 243 255;   /* violet-50  */
+  --accent-100: 237 233 254;   /* violet-100 */
+  --accent-400: 167 139 250;   /* violet-400 */
+  --accent-500: 139 92 246;    /* violet-500 */
+  --accent-600: 124 58 237;    /* violet-600 */
+  --accent-700: 109 40 217;    /* violet-700 */
+}
+
+[data-quiz-theme="links"] {
+  --accent-50:  255 251 235;   /* amber-50  */
+  --accent-100: 254 243 199;   /* amber-100 */
+  --accent-400: 251 191 36;    /* amber-400 */
+  --accent-500: 245 158 11;    /* amber-500 */
+  --accent-600: 217 119 6;     /* amber-600 */
+  --accent-700: 180 83 9;      /* amber-700 */
+}
+
 @layer components {
   /* Sticky page header — used by standard scroll-layout pages */
   .site-header {
@@ -46,9 +88,9 @@ body {
     @apply rounded-xl border bg-white shadow-sm;
   }
 
-  /* Primary action button */
+  /* Primary action button — uses quiz accent color */
   .btn-primary {
-    @apply bg-blue-600 text-white hover:bg-blue-700 transition
+    @apply bg-accent-600 text-white hover:bg-accent-700 transition
            rounded-lg px-4 py-2 text-sm font-medium;
   }
 

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -57,20 +57,25 @@ body {
 }
 
 @layer components {
-  /* Sticky page header — used by all study pages */
+  /* ── Single source of truth for horizontal page padding ──
+     Change px-8 / sm:px-12 here to shift header + body padding everywhere. */
+  .px-page {
+    @apply px-2 sm:px-12;
+  }
+
+  /* page header — used by all pages */
   .site-header {
-    @apply sticky top-0 z-10 bg-white border-b px-4 py-3 sm:px-12 sm:py-4;
+    @apply bg-white border-b py-3 sm:py-4 px-page;
   }
 
   /* Header inner row — title + buttons, wraps on small screens */
   .site-header-inner {
-    @apply max-w-6xl 2xl:max-w-screen-2xl mx-auto
-           flex flex-wrap items-center justify-between gap-y-2;
+    @apply flex flex-wrap items-center justify-between gap-y-2;
   }
 
   /* Standard page content container */
   .page-container {
-    @apply px-4 py-6 sm:px-12 sm:py-8;
+    @apply px-page py-4 sm:py-6;
   }
 
   /* Page-level h1 */

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,7 +6,18 @@ module.exports = {
     "./lib/**/*.{ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        accent: {
+          50:  "rgb(var(--accent-50)  / <alpha-value>)",
+          100: "rgb(var(--accent-100) / <alpha-value>)",
+          400: "rgb(var(--accent-400) / <alpha-value>)",
+          500: "rgb(var(--accent-500) / <alpha-value>)",
+          600: "rgb(var(--accent-600) / <alpha-value>)",
+          700: "rgb(var(--accent-700) / <alpha-value>)",
+        },
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary

- Introduced per-quiz AI assistant theming, a shared `PageHeader`, and a centralized study step library (`lib/studySteps.ts`) as a single source of truth for all step types, subtitles, and survey stage config
- Redesigned the dashboard with a prominent "Next Step" hero card, cleaner admin/study-flow sections with distinct icons, and consistent card sizing
- Fixed quiz page layout so the chat column scrolls naturally at high zoom levels without breaking the fixed-height layout at normal zoom
- Resolved `sendChat` signature conflict from `weedguet-branch` merge — consolidated flat params back into the options object and removed unused `onCitations` callback
- Fixed `answer_incorrectly` metadata saving in the double-agent chat endpoint to use `_schedule_exchange_save` (sequential, GC-safe) instead of two racing `asyncio.create_task` calls

## Changes by area

### Frontend — UI & layout

- **`components/PageHeader.tsx`** *(new)*: shared header component used across all pages (quiz, survey, dashboard, admin, chat, playground, profile) — standardizes title/subtitle sizing, dashboard and logout buttons
- **`styles/globals.css`**: added `.site-header`, `.px-page`, `.page-container`, `.btn-primary`, `.btn-secondary` utilities; header and body padding now controlled from one place
- **`lib/quizTheme.ts`** *(new)*: `data-quiz-theme` CSS variable scoping for per-assistant accent colors (base, followup, double, links)
- **`components/ChatHeader.tsx`** *(new)*: per-quiz colored header with assistant name and info popup
- **`pages/quiz/[quiz_id].tsx`**: quiz layout fixes — chat column uses `md:sticky md:top-0 md:h-[min(calc(100vh-9rem),80vw)]` with `[@media(max-height:700px)]` short-viewport fallback; outer wrapper uses `h-[100dvh] overflow-hidden` with `[@media(max-height:760px)]` scroll escape
- **`pages/playground.tsx`**: quiz-type toggle buttons now use `data-quiz-theme` accent colors from `globals.css` instead of hardcoded Tailwind colors
- **`components/QuestionBox.tsx`**, **`components/MarkdownMessage.tsx`**: minor sizing and style consistency fixes

### Frontend — Dashboard

- **`pages/dashboard.tsx`**: full redesign — full-width "Next Step" hero card (earliest incomplete step, blue header, subtitle, estimated time, Start/Continue verb); admin section with tool cards (Chat, Playground, Admin Panel) separated from study flow section (4-col quiz cards with per-theme accent colors, 3-col survey cards)

### Frontend — Study flow centralization

- **`lib/studySteps.ts`** *(new)*: central module for `SurveyStage`, `ActiveSurveyStage`, `QuizId`, `VariantQuizId`, `StudyStepId`, `StudyStep`, `STEP_SUBTITLES`, `STAGE_CONFIG`, `buildStudySteps`, `isActiveSurveyStage`, `isVariantQuizId`
- **`components/ProgressBar.tsx`** *(new)*: study progress stepper used on dashboard and survey sidebar — supports horizontal and vertical layouts, collapsible, active step highlight
- **`pages/survey.tsx`**: removed local type/config duplicates; imports from `lib/studySteps`; replaced local `ExtendedUser` with base `User`
- **`pages/quiz/[quiz_id].tsx`**: same — removed local `VARIANT_QUIZ_IDS`, `QuizId`, `SurveyStage`, `ExtendedUser`; subtitle text now pulled from `STEP_SUBTITLES`

### Frontend — Chat

- **`lib/chat.ts`**: resolved merge conflict — `sendChat` signature uses options-object pattern; `answerIncorrectly` and `answerChoices` moved into `SendChatOptions`; removed unused `onCitations` callback (citations still injected into reply text internally)
- **`components/ChatBox.tsx`**: updated `sendChat` call to pass `answerIncorrectly`/`answerChoices` inside the options object

### Backend — Chat

- **`app/api/chat.py`**: extended `_schedule_exchange_save` to accept optional `assistant_metadata`; resolved two merge conflicts (double-agent endpoint and links endpoint) to use `_schedule_exchange_save` with `AIMessageMetadata(answer_incorrectly=...)` — preserves sequential user→assistant save ordering and GC-safe task lifetime
- **`app/schemas/message.py`**: `AIMessageMetadata` schema extended with `answer_incorrectly` field
- **`app/schemas/quiz.py`**, **`app/services/quiz.py`**: minor fixes from `weedguet-branch` merge

### Infrastructure

- **`docker-compose.yml`**: frontend hot reload on file changes — no image rebuild needed during development
- **`.gitignore`**: added Claude Code artifacts

## Test plan

- [ ] Pre-quiz survey → base quiz → post-base survey → variant quiz → final survey flow completes end-to-end for a non-admin user
- [ ] Quiz page fits viewport at normal zoom (no scroll); scrolls naturally when zoomed in or on short viewports
- [ ] All four quiz themes (base, followup, double, links) show correct accent colors in quiz header, buttons, and progress bar
- [ ] Dashboard "Next Step" hero card points to the earliest incomplete step with correct Start/Continue verb
- [ ] Admin study flow and tool cards all navigate correctly
- [ ] Chat streaming works for all endpoints (standard, followup, links, double); `answer_incorrectly` flag saves correctly to DB
- [ ] Playground quiz-type toggle buttons use themed accent colors
