### PR TITLE
feat: add IRB consent page to the signup flow

### DIFF
--- a/backend/app/services/link_health.py
+++ b/backend/app/services/link_health.py
@@ -19,6 +19,10 @@ PREDEFINED_TAGS = [
     "Other",
 ]
 
+# "Other" is a catch-all fallback for untagged links (see is_relevant below),
+# not a real subject — searching for it during discovery returns junk.
+DISCOVERABLE_TAGS = [tag for tag in PREDEFINED_TAGS if tag != "Other"]
+
 
 # ── HTTP health check ────────────────────────────────────────────────────────
 
@@ -208,7 +212,7 @@ def run_discovery(db, settings, openai_client: OpenAI, allowlist_cache: set) -> 
     discovered = 0
     now = datetime.now(timezone.utc)
 
-    for tag in PREDEFINED_TAGS:
+    for tag in DISCOVERABLE_TAGS:
         live_count = col.count_documents({"tags": tag, "status": "READY"})
         if live_count >= settings.MAX_LIVE_LINKS_PER_SUBJECT:
             continue

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -175,6 +175,9 @@ _STOP_WORDS = frozenset({
 
 _RE_UNLINKED_PREFIX = r"(?<!\[)\b"
 _RE_UNLINKED_SUFFIX = r"\b(?!\])"
+# Matches a fully-formed `[text](url)` link, allowing one level of balanced
+# parentheses inside the URL (e.g. Wikipedia's "Mitosis_(biology)").
+_RE_MARKDOWN_LINK = re.compile(r"\[[^\[\]]*\]\([^()]*(?:\([^()]*\)[^()]*)*\)")
 _RE_FORMULA_CHARS = re.compile(r"[=÷×≥≤≠→←+\-*/\\|^]")
 
 
@@ -185,12 +188,22 @@ def _title_keywords(title: str) -> list[str]:
     return sorted(candidates, key=len, reverse=True)
 
 
+def _markdown_link_spans(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) spans of every fully-formed `[text](url)` link in text."""
+    return [m.span() for m in _RE_MARKDOWN_LINK.finditer(text)]
+
+
 def _unlinked_search(term: str, text: str) -> re.Match | None:
-    """Find the first occurrence of term in text that is not already inside a markdown link."""
-    return re.search(
-        _RE_UNLINKED_PREFIX + re.escape(term) + _RE_UNLINKED_SUFFIX,
-        text, re.IGNORECASE,
-    )
+    """Find the first occurrence of term in text that is not already part of
+    a markdown link, i.e. not in a `[display text]` and not inside a `(url)`
+    destination of a link already inserted by an earlier citation.
+    """
+    spans = _markdown_link_spans(text)
+    pattern = re.compile(_RE_UNLINKED_PREFIX + re.escape(term) + _RE_UNLINKED_SUFFIX, re.IGNORECASE)
+    for match in pattern.finditer(text):
+        if not any(start <= match.start() < end for start, end in spans):
+            return match
+    return None
 
 
 def _place_marker_inline(phrase: str, url: str, before_marker: str, after_marker: str) -> str:

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -13,6 +13,7 @@ from app.services.search import (
     _filter_valid_urls,
     _build_search_context,
     _title_keywords,
+    _markdown_link_spans,
     _unlinked_search,
     _place_marker_inline,
     _inject_citation_links,
@@ -347,6 +348,37 @@ class TestTitleKeywords:
         assert "An" not in keywords
 
 
+# ── _markdown_link_spans ──────────────────────────────────────────────────────
+
+class TestMarkdownLinkSpans:
+    def test_finds_single_link_span(self):
+        text = "See [probability](https://example.com/prob) for details."
+        spans = _markdown_link_spans(text)
+
+        assert len(spans) == 1
+        start, end = spans[0]
+        assert text[start:end] == "[probability](https://example.com/prob)"
+
+    def test_finds_multiple_link_spans(self):
+        text = "[A](https://example.com/a) and [B](https://example.com/b)."
+        spans = _markdown_link_spans(text)
+
+        assert len(spans) == 2
+        assert text[spans[0][0]:spans[0][1]] == "[A](https://example.com/a)"
+        assert text[spans[1][0]:spans[1][1]] == "[B](https://example.com/b)"
+
+    def test_handles_balanced_parens_in_url(self):
+        text = "See [biology](https://en.wikipedia.org/wiki/Mitosis_(biology)) for details."
+        spans = _markdown_link_spans(text)
+
+        assert len(spans) == 1
+        start, end = spans[0]
+        assert text[start:end] == "[biology](https://en.wikipedia.org/wiki/Mitosis_(biology))"
+
+    def test_no_links_returns_empty_list(self):
+        assert _markdown_link_spans("Plain text with no links.") == []
+
+
 # ── _unlinked_search ──────────────────────────────────────────────────────────
 
 class TestUnlinkedSearch:
@@ -361,6 +393,20 @@ class TestUnlinkedSearch:
         match = _unlinked_search("probability", text)
         assert match is None
 
+    def test_does_not_match_term_inside_already_linked_url(self):
+        # "calculate" appears inside a URL that was already turned into a
+        # markdown link by an earlier citation — must not be matched again.
+        text = (
+            "Read about probabilities"
+            "[1](https://www.geeksforgeeks.org/maths/how-to-calculate-dice-probabilities/)."
+            " Learn how to calculate it."
+        )
+        match = _unlinked_search("calculate", text)
+
+        assert match is not None
+        # The only valid match is the standalone "calculate" outside the link.
+        assert text[:match.start()].endswith("how to ")
+
     def test_case_insensitive(self):
         text = "PROBABILITY is fun."
         match = _unlinked_search("probability", text)
@@ -369,6 +415,15 @@ class TestUnlinkedSearch:
     def test_no_match_returns_none(self):
         text = "This text has nothing relevant."
         match = _unlinked_search("probability", text)
+        assert match is None
+
+    def test_returns_none_when_only_occurrence_is_inside_linked_url(self):
+        text = (
+            "Read about probabilities"
+            "[1](https://www.geeksforgeeks.org/maths/how-to-calculate-dice-probabilities/)."
+        )
+        match = _unlinked_search("calculate", text)
+
         assert match is None
 
 
@@ -476,6 +531,40 @@ class TestInjectCitationLinks:
         text = "Plain text with no markers."
         result = _inject_citation_links(text, [])
         assert result == "Plain text with no markers."
+
+    def test_citation_phrase_inside_earlier_citation_url_does_not_nest_links(self):
+        # Regression test: citation 1's URL contains the word "calculate",
+        # which is also the phrase citation 2 wants to link. Citation 1 is
+        # processed first (via the bare [1] marker), turning its URL into
+        # part of the text. Citation 2's phrase "calculate" must NOT be
+        # matched inside that already-inserted URL, which would otherwise
+        # splice a second markdown link into the middle of the first one's
+        # destination.
+        text = "Read about probabilities[1]. Learn how to [calculate][2] it."
+        citations = [
+            {
+                "n": 1,
+                "title": "Dice Probabilities",
+                "url": "https://www.geeksforgeeks.org/maths/how-to-calculate-dice-probabilities/",
+            },
+            {
+                "n": 2,
+                "title": "Calculate",
+                "url": "https://www.investopedia.com/terms/m/median.asp",
+            },
+        ]
+
+        result = _inject_citation_links(text, citations)
+
+        # Citation 1's URL must remain intact, with no link nested inside it.
+        assert (
+            "(https://www.geeksforgeeks.org/maths/how-to-calculate-dice-probabilities/)"
+            in result
+        )
+        # Citation 2 must be its own separate, well-formed link.
+        assert "[calculate](https://www.investopedia.com/terms/m/median.asp)" in result
+        # No markdown link should appear nested inside another's URL.
+        assert "[calculate](https://www.investopedia.com/terms/m/median.asp)-dice" not in result
 
 
 # ── get_chat_response_with_search ──────────────────────────────────────────────

--- a/frontend/__tests__/components/AuthForm.test.tsx
+++ b/frontend/__tests__/components/AuthForm.test.tsx
@@ -195,7 +195,7 @@ describe("AuthForm", () => {
           consent: true,
         })
       );
-      await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard"));
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/consent"));
     });
 
     it("renders a link to the login page", () => {

--- a/frontend/__tests__/pages/consent.test.tsx
+++ b/frontend/__tests__/pages/consent.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ConsentPage from "../../pages/consent";
+import { getMe, logout } from "../../lib/auth";
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+jest.mock("next/router", () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+}));
+
+jest.mock("../../lib/auth", () => ({
+  getMe: jest.fn(),
+  logout: jest.fn(),
+}));
+
+const mockGetMe = getMe as jest.Mock;
+const mockLogout = logout as jest.Mock;
+
+const authedUser = { id: "1", email: "user@example.com", is_admin: false };
+
+describe("ConsentPage", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockPush.mockClear();
+    mockGetMe.mockReset();
+    mockLogout.mockReset();
+  });
+
+  it("shows a loading state before the session check resolves", () => {
+    mockGetMe.mockReturnValue(new Promise(() => {}));
+    render(<ConsentPage />);
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("redirects to login when the session check fails", async () => {
+    mockGetMe.mockRejectedValue(new Error("not authenticated"));
+    render(<ConsentPage />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
+  });
+
+  it("renders the consent form once authenticated", async () => {
+    mockGetMe.mockResolvedValue({ user: authedUser });
+    render(<ConsentPage />);
+
+    expect(await screen.findByText("Research Consent Form")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Understanding Overreliance towards AI in Educational Settings/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Neha Rani \(Faculty in CISE\)/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "neharani@ufl.edu" })
+    ).toHaveAttribute("href", "mailto:neharani@ufl.edu");
+  });
+
+  it("renders all required information sections", async () => {
+    mockGetMe.mockResolvedValue({ user: authedUser });
+    render(<ConsentPage />);
+
+    await screen.findByText("Research Consent Form");
+
+    expect(screen.getByText("Purpose of the Study")).toBeInTheDocument();
+    expect(screen.getByText("What will you be asked to do")).toBeInTheDocument();
+    expect(screen.getByText("Time Required")).toBeInTheDocument();
+    expect(screen.getByText("Research Benefits")).toBeInTheDocument();
+    expect(screen.getByText("Research Risks")).toBeInTheDocument();
+    expect(screen.getByText("Statement of Confidentiality")).toBeInTheDocument();
+    expect(
+      screen.getByText("Who to contact if you have questions or injured")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Voluntary Participation")).toBeInTheDocument();
+    expect(screen.getByText(/about 45 minutes/)).toBeInTheDocument();
+    expect(screen.getByText(/352-273-9600/)).toBeInTheDocument();
+  });
+
+  it("renders the agree and decline buttons", async () => {
+    mockGetMe.mockResolvedValue({ user: authedUser });
+    render(<ConsentPage />);
+
+    expect(await screen.findByRole("button", { name: "I agree to participate" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "I do not wish to participate" })).toBeInTheDocument();
+  });
+
+  it("navigates to the dashboard when the user agrees", async () => {
+    mockGetMe.mockResolvedValue({ user: authedUser });
+    render(<ConsentPage />);
+
+    const agreeButton = await screen.findByRole("button", { name: "I agree to participate" });
+    fireEvent.click(agreeButton);
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard"));
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it("logs out and redirects to login when the user declines", async () => {
+    mockGetMe.mockResolvedValue({ user: authedUser });
+    mockLogout.mockResolvedValue(undefined);
+    render(<ConsentPage />);
+
+    const declineButton = await screen.findByRole("button", { name: "I do not wish to participate" });
+    fireEvent.click(declineButton);
+
+    await waitFor(() => expect(mockLogout).toHaveBeenCalled());
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("redirects to login even if logout fails when the user declines", async () => {
+    mockGetMe.mockResolvedValue({ user: authedUser });
+    mockLogout.mockRejectedValue(new Error("network error"));
+    render(<ConsentPage />);
+
+    const declineButton = await screen.findByRole("button", { name: "I do not wish to participate" });
+    fireEvent.click(declineButton);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
+  });
+});

--- a/frontend/components/AuthForm.tsx
+++ b/frontend/components/AuthForm.tsx
@@ -52,6 +52,7 @@ export default function AuthForm({ mode }: Props) {
     try {
       if (mode === "login") {
         await login(email.trim(), password);
+        router.push("/dashboard");
       } else {
         await signup({
           firstName: firstName.trim(),
@@ -60,9 +61,8 @@ export default function AuthForm({ mode }: Props) {
           password,
           consent,
         });
+        router.push("/consent");
       }
-
-      router.push("/dashboard");
     } catch (err: any) {
       setError(err?.message || "Something went wrong.");
     } finally {

--- a/frontend/pages/consent.tsx
+++ b/frontend/pages/consent.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { getMe, logout } from "../lib/auth";
+
+export default function ConsentPage() {
+  const router = useRouter();
+  const [checking, setChecking] = useState(true);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await getMe();
+      } catch {
+        if (!cancelled) {
+          router.replace("/login");
+          return;
+        }
+      } finally {
+        if (!cancelled) setChecking(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (checking) {
+    return (
+      <div className="grid min-h-screen place-items-center">
+        <div className="text-gray-500">Loading…</div>
+      </div>
+    );
+  }
+
+  async function onAgree() {
+    if (pending) return;
+    setPending(true);
+    router.push("/dashboard");
+  }
+
+  async function onDecline() {
+    if (pending) return;
+    setPending(true);
+    try {
+      await logout();
+    } catch {
+      // Ignore — still navigate away below regardless of logout outcome.
+    } finally {
+      router.replace("/login");
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="mx-auto max-w-2xl rounded-2xl border bg-white p-6 shadow-sm">
+        <h1 className="mb-4 text-xl font-semibold">Research Consent Form</h1>
+
+        <div className="mb-4 space-y-1 text-sm text-gray-700">
+          <p>
+            <span className="font-medium">Title of Project:</span> Understanding
+            Overreliance towards AI in Educational Settings
+          </p>
+          <p>
+            <span className="font-medium">Principal Investigator:</span> Neha
+            Rani (Faculty in CISE) —{" "}
+            <a className="underline" href="mailto:neharani@ufl.edu">
+              neharani@ufl.edu
+            </a>
+          </p>
+        </div>
+
+        <div className="space-y-4 text-sm text-gray-700">
+          <p>
+            Please read the information below carefully before you decide to
+            participate in this research study. Your participation is
+            voluntary. You can decide not to participate or later decide to
+            stop participating at any time without penalty or lose any
+            benefits that would normally be expected.
+          </p>
+
+          <section>
+            <h2 className="font-semibold text-gray-900">Purpose of the Study</h2>
+            <p className="mt-1">
+              The purpose of this research study is to understand students&apos;
+              overreliance on AI in educational settings.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-gray-900">
+              What will you be asked to do
+            </h2>
+            <p className="mt-1">
+              If you agree to take part in this study, you will be engaged in
+              an online study. You will be asked to fill out questionnaires
+              asking about your demographics and your experience with AI
+              tools. You will be asked to answer a few mathematics questions,
+              specifically statistics, permutations, and combinations. You
+              will also have an AI chat assistant to help you with
+              problem-solving. You will be asked to fill out a post survey as
+              well.
+            </p>
+          </section>
+
+          <p>
+            If you have any questions now or at any time during the study,
+            please contact the Principal Investigator listed above.
+          </p>
+
+          <section>
+            <h2 className="font-semibold text-gray-900">Time Required</h2>
+            <p className="mt-1">
+              It will take about 45 minutes to participate in the research.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-gray-900">Research Benefits</h2>
+            <p className="mt-1">
+              There are no direct benefits to you for being in this study.
+              There may be a benefit to others depending on the results of
+              this study.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-gray-900">Research Risks</h2>
+            <p className="mt-1">
+              There are no known risks beyond those normally encountered in
+              daily life (loss of time, boredom) for a participant. There are
+              no direct benefits of study participation.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-gray-900">
+              Statement of Confidentiality
+            </h2>
+            <p className="mt-1">
+              Your participation in this research is confidential.
+              Information collected about you will be stored in computers
+              with security passwords or in locked filing cabinets. Only
+              certain people have the legal right to review these research
+              records, and they will protect the secrecy (confidentiality) of
+              these records as much as the law allows. These people include
+              the researchers for this study, certain University of Florida
+              officials, and the Institutional Review Board (IRB; an IRB is a
+              group of people who are responsible for looking after the
+              rights and welfare of people taking part in research).
+              Otherwise your research records will not be released without
+              your permission unless required by law or a court order. The
+              researchers will not share your name or other identifiable
+              information about you if they publish, present, or share the
+              results this research.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-gray-900">
+              Who to contact if you have questions or injured
+            </h2>
+            <p className="mt-1">
+              Please contact Neha Rani at (352) 871 5080 with questions or
+              concerns about this study.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-semibold text-gray-900">
+              Voluntary Participation
+            </h2>
+            <p className="mt-1">
+              Your decision to be in this research is voluntary. You do not
+              have to do any study activities that you do not want to take
+              part in. You can stop at any time. If you decide you want to
+              stop participating in the research, you can let the research
+              team know or call the Principal Investigator at any time at
+              (352) 871 5080. If you choose not to take part, this will have
+              no effect on you or your relationships with the University of
+              Florida. If you have any questions about your rights as a
+              research subject, you can phone the Institutional Review Board
+              at 352-273-9600.
+            </p>
+          </section>
+
+          <p>
+            Participation in the research implies that you have read the
+            information in this form and consent to take part in the
+            research. Please save a copy of this form for your records or
+            future reference.
+          </p>
+        </div>
+
+        <div className="mt-6 border-t pt-4">
+          <p className="mb-4 text-sm text-gray-700">
+            If you want to participate in this research study, click the{" "}
+            <span className="font-medium">&quot;I agree to participate&quot;</span>{" "}
+            button below. If you do not want to participate, you may simply
+            close this window or click{" "}
+            <span className="font-medium">
+              &quot;I do not wish to participate&quot;
+            </span>
+            .
+          </p>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              onClick={onAgree}
+              disabled={pending}
+              className="flex-1 rounded-xl bg-blue-600 px-4 py-2 font-medium text-white disabled:opacity-60"
+            >
+              I agree to participate
+            </button>
+            <button
+              type="button"
+              onClick={onDecline}
+              disabled={pending}
+              className="flex-1 rounded-xl border px-4 py-2 font-medium text-gray-700 disabled:opacity-60"
+            >
+              I do not wish to participate
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Summary
- Adds a new `/consent` page shown immediately after signup, displaying the full IRB informed-consent information sheet (study title, PI contact, purpose, procedures, time required, benefits/risks, confidentiality, contact info, and voluntary participation).
- After signup, `AuthForm` now redirects to `/consent` instead of `/dashboard` (login still goes straight to `/dashboard`, since returning users have already completed this step).
- The consent page requires an explicit choice:
  - **"I agree to participate"** → proceeds to `/dashboard`
  - **"I do not wish to participate"** → logs the user out and redirects to `/login` (navigation happens regardless of whether the logout call succeeds)
- The page is auth-gated via `getMe()`, showing a loading state and redirecting unauthenticated users to `/login`, consistent with the existing `demographics` page pattern.