### PR TITLE
fix(links): avoid flagging links dead on WAF/bot-block responses

### DIFF
--- a/backend/app/services/link_health.py
+++ b/backend/app/services/link_health.py
@@ -26,6 +26,24 @@ DISCOVERABLE_TAGS = [tag for tag in PREDEFINED_TAGS if tag != "Other"]
 
 # ── HTTP health check ────────────────────────────────────────────────────────
 
+# A realistic browser fingerprint. Sites guarded by anti-bot/WAF services (Cloudflare,
+# Akamai, etc.) often block bare "Mozilla/5.0" requests with 401/402/403 even though
+# the page is genuinely live and accessible to a real browser.
+_BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+# Status codes that commonly indicate an anti-bot/WAF block rather than a genuinely
+# dead or restricted page — treat as reachable so a real block doesn't get conflated
+# with a removed page.
+_BOT_BLOCK_STATUS_CODES = {401, 402, 403}
+
+
 def fetch_with_retries(
     url: str,
     max_retries: int = 3,
@@ -42,10 +60,13 @@ def fetch_with_retries(
     for attempt in range(max_retries):
         try:
             with httpx.Client(timeout=timeout, follow_redirects=True) as client:
-                resp = client.get(url, headers={"User-Agent": "Mozilla/5.0"})
+                resp = client.get(url, headers=_BROWSER_HEADERS)
 
             if resp.status_code == 404:
                 return False, 404, "http_error"
+
+            if resp.status_code in _BOT_BLOCK_STATUS_CODES:
+                return True, resp.status_code, None
 
             if resp.status_code >= 400:
                 return False, resp.status_code, "http_error"

--- a/backend/tests/test_link_health_service.py
+++ b/backend/tests/test_link_health_service.py
@@ -57,6 +57,44 @@ class TestFetchWithRetries:
         assert code == 500
         assert error == "http_error"
 
+    def test_401_treated_as_ok_bot_block(self):
+        """401/402/403 commonly come from anti-bot/WAF blocks rather than a
+        genuinely dead page, so they should not be flagged as failures."""
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(_make_resp(401))):
+            ok, code, error = fetch_with_retries("https://example.com/page", max_retries=1, timeout=5)
+        assert ok is True
+        assert code == 401
+        assert error is None
+
+    def test_402_treated_as_ok_bot_block(self):
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(_make_resp(402))):
+            ok, code, error = fetch_with_retries("https://example.com/page", max_retries=1, timeout=5)
+        assert ok is True
+        assert code == 402
+        assert error is None
+
+    def test_403_treated_as_ok_bot_block(self):
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(_make_resp(403))):
+            ok, code, error = fetch_with_retries("https://example.com/page", max_retries=1, timeout=5)
+        assert ok is True
+        assert code == 403
+        assert error is None
+
+    def test_sends_realistic_browser_headers(self):
+        """A bare 'Mozilla/5.0' UA with no Accept headers is itself a bot signal
+        to many WAFs — make sure we send a fuller, realistic header set."""
+        resp = _make_resp(200)
+        ctx = _mock_httpx_client(resp)
+        with patch("app.services.link_health.httpx.Client", return_value=ctx) as mock_client_cls:
+            fetch_with_retries("https://example.com/page", max_retries=1, timeout=5)
+
+        mock_client = ctx.__enter__.return_value
+        _, kwargs = mock_client.get.call_args
+        headers = kwargs["headers"]
+        assert "Chrome" in headers["User-Agent"]
+        assert "Accept" in headers
+        assert "Accept-Language" in headers
+
     def test_redirect_to_root_returns_redirect_root(self):
         # Original URL has a path; final URL is the bare root → page was removed
         resp = _make_resp(301, url="https://example.com")  # final URL has no path


### PR DESCRIPTION
### Summary
- `fetch_with_retries` now sends a realistic browser header set (full Chrome
  User-Agent + `Accept` + `Accept-Language`) instead of a bare
  `"User-Agent: Mozilla/5.0"`.
- HTTP 401, 402, and 403 responses are now treated as reachable
  (`ok=True`) instead of `http_error`.

### Why
Many sites guarded by anti-bot/WAF services (Cloudflare, Akamai, etc.)
block requests with a minimal/incomplete User-Agent and no standard
browser headers, responding with 401/402/403 even though the page is
genuinely live and accessible in a real browser. The health checker was
treating these blocked responses the same as a real 404, which:
- degraded READY links to `NOT_READY` even though they were actually fine, and
- caused discovery to skip otherwise-valid candidate links.