### PR TITLE
feat(links): add Explore button to fetch live page metadata and re-judge relevance

### DIFF
--- a/backend/app/api/knowledge_links.py
+++ b/backend/app/api/knowledge_links.py
@@ -1,7 +1,9 @@
 # backend/app/api/knowledge_links.py
+import os
 import threading
 from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Request, Depends, Query
+from openai import OpenAI
 
 from ..schemas.knowledge_link import (
     KnowledgeLinkCreate,
@@ -19,6 +21,7 @@ from ..services.knowledge_links import (
     delete_knowledge_link,
     approve_link,
     reject_link,
+    explore_link,
 )
 
 router = APIRouter(prefix="/knowledge-links", tags=["knowledge-links"])
@@ -143,6 +146,43 @@ def approve_knowledge_link(
         "url": str(result.url),
         "description": result.description,
     })
+    return result
+
+
+@router.post("/{link_id}/explore", response_model=KnowledgeLinkPublic)
+def explore_knowledge_link(
+    link_id: str,
+    request: Request,
+    user: UserPublic = Depends(require_admin),
+):
+    """Fetch the live page, update title/description from HTML meta tags, re-run the
+    relevance judge with the enriched content, and return the updated link state."""
+    links = get_knowledge_links_collection(request.app.state.db)
+    openai_client = OpenAI(
+        api_key=os.getenv("UF_OPENAI_API_KEY"),
+        base_url=os.getenv("UF_OPENAI_BASE_URL", "https://api.ai.it.ufl.edu"),
+    )
+    result = explore_link(
+        links,
+        link_id,
+        openai_client,
+        request.app.state.allowlist_cache,
+        timeout=request.app.state.settings.LINK_REQUEST_TIMEOUT,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Link not found or is tombstoned")
+
+    # Keep chatbot cache consistent with any status changes
+    request.app.state.knowledge_links = [
+        l for l in request.app.state.knowledge_links if l["id"] != link_id
+    ]
+    if result.status.value == "READY":
+        request.app.state.knowledge_links.append({
+            "id": result.id,
+            "title": result.title,
+            "url": str(result.url),
+            "description": result.description,
+        })
     return result
 
 

--- a/backend/app/services/knowledge_links.py
+++ b/backend/app/services/knowledge_links.py
@@ -171,6 +171,69 @@ def reject_link(links: Collection, link_id: str) -> Optional[KnowledgeLinkPublic
     return _to_public(updated) if updated else None
 
 
+def explore_link(
+    links: Collection,
+    link_id: str,
+    openai_client,
+    allowlist_cache: set,
+    timeout: int = 10,
+) -> Optional[KnowledgeLinkPublic]:
+    """Fetch the link's live page, update its stored title/description from HTML meta
+    tags, re-run the relevance judge with the enriched content, and return the updated
+    document.
+
+    Status transitions follow the same rules as run_health_check:
+      READY + fails relevance  → NOT_READY
+      NOT_READY + passes relevance → NEEDS_REVIEW
+    Returns None for REJECTED links or invalid IDs.
+    """
+    from .link_health import fetch_page_metadata, is_relevant
+
+    if not ObjectId.is_valid(link_id):
+        return None
+    doc = links.find_one({"_id": ObjectId(link_id)})
+    if not doc or doc.get("status") == "REJECTED":
+        return None
+
+    url = doc.get("url", "")
+    tag = doc["tags"][0] if doc.get("tags") else "Other"
+    now = datetime.now(timezone.utc)
+
+    fetched_title, fetched_description, http_code = fetch_page_metadata(url, timeout=timeout)
+
+    update: dict = {"last_checked": now, "updated_at": now}
+    if http_code is not None:
+        update["last_http_code"] = http_code
+
+    # Only overwrite stored fields when the page returned real content
+    new_title = fetched_title if fetched_title else doc.get("title", "")
+    new_description = fetched_description if fetched_description else doc.get("description", "")
+    if fetched_title:
+        update["title"] = fetched_title
+    if fetched_description:
+        update["description"] = fetched_description
+
+    link_dict = {"url": url, "title": new_title, "description": new_description}
+    relevant, relevance_reason = is_relevant(tag, link_dict, openai_client, allowlist_cache)
+
+    current_status = doc.get("status", "READY")
+    if current_status == "READY" and not relevant:
+        update["status"] = "NOT_READY"
+        update["active"] = False
+        update["last_error_type"] = relevance_reason
+    elif current_status == "NOT_READY" and relevant:
+        update["status"] = "NEEDS_REVIEW"
+        update["last_error_type"] = None
+    elif relevant:
+        update["last_error_type"] = None
+    else:
+        update["last_error_type"] = relevance_reason
+
+    links.update_one({"_id": ObjectId(link_id)}, {"$set": update})
+    updated = links.find_one({"_id": ObjectId(link_id)})
+    return _to_public(updated) if updated else None
+
+
 def reload_knowledge_links_cache(links: Collection) -> list:
     """Return list of READY link dicts for use in app.state.knowledge_links."""
     return [

--- a/backend/app/services/link_health.py
+++ b/backend/app/services/link_health.py
@@ -1,6 +1,7 @@
 # backend/app/services/link_health.py
 import asyncio
 import os
+import re
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -42,6 +43,59 @@ _BROWSER_HEADERS = {
 # dead or restricted page — treat as reachable so a real block doesn't get conflated
 # with a removed page.
 _BOT_BLOCK_STATUS_CODES = {401, 402, 403}
+
+_RE_TITLE_TAG = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+
+def _meta_content(html: str, attr: str, value: str) -> str:
+    """Return the content= of the first <meta> tag that has attr=value (either attribute order)."""
+    # attr=value before content=
+    m = re.search(
+        r"<meta\b[^>]*\b" + re.escape(attr) + r"\s*=\s*[\"']" + re.escape(value) + r"[\"'][^>]*\bcontent\s*=\s*[\"']([^\"'<>]*)[\"']",
+        html, re.IGNORECASE,
+    )
+    if m:
+        return m.group(1)
+    # content= before attr=value
+    m = re.search(
+        r"<meta\b[^>]*\bcontent\s*=\s*[\"']([^\"'<>]*)[\"'][^>]*\b" + re.escape(attr) + r"\s*=\s*[\"']" + re.escape(value) + r"[\"']",
+        html, re.IGNORECASE,
+    )
+    return m.group(1) if m else ""
+
+
+def fetch_page_metadata(
+    url: str,
+    timeout: int = 10,
+) -> tuple[str, str, Optional[int]]:
+    """Fetch url and extract (title, description, http_code) from its HTML meta tags.
+
+    Returns ("", "", http_code) when unreachable, non-HTML, or metadata is absent.
+    Bot-blocked responses (401/402/403) return ("", "", http_code) without parsing.
+    """
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            resp = client.get(url, headers=_BROWSER_HEADERS)
+        http_code = resp.status_code
+        if resp.status_code != 200:
+            return "", "", http_code
+        if "html" not in resp.headers.get("content-type", "").lower():
+            return "", "", http_code
+        html = resp.text[:51200]  # first 50 KB — meta tags are always in <head>
+    except Exception:
+        return "", "", None
+
+    _title_m = _RE_TITLE_TAG.search(html)
+    title = (
+        _meta_content(html, "property", "og:title")
+        or _meta_content(html, "name", "title")
+        or (_title_m.group(1).strip() if _title_m else "")
+    )
+    description = (
+        _meta_content(html, "property", "og:description")
+        or _meta_content(html, "name", "description")
+    )
+    return title.strip(), description.strip(), http_code
 
 
 def fetch_with_retries(

--- a/backend/tests/test_knowledge_links_service.py
+++ b/backend/tests/test_knowledge_links_service.py
@@ -1,7 +1,7 @@
 # backend/tests/test_knowledge_links_service.py
 """Unit tests for the knowledge-links service: CRUD, approve/reject, cache, tag normalization."""
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 from bson import ObjectId
 import pytest
 
@@ -11,6 +11,7 @@ from app.services.knowledge_links import (
     create_knowledge_link,
     approve_link,
     reject_link,
+    explore_link,
     reload_knowledge_links_cache,
     list_knowledge_links_by_status,
     update_knowledge_link,
@@ -265,6 +266,120 @@ class TestListKnowledgeLinksByStatus:
         col.find.return_value.sort.return_value = [doc]
         results = list_knowledge_links_by_status(col, None)
         assert results[0].status == LinkStatus.READY
+
+
+# ── explore_link ──────────────────────────────────────────────────────────────
+
+class TestExploreLink:
+    def _make_doc(self, oid, status="READY"):
+        return {
+            "_id": oid,
+            "title": "Link Title",
+            "url": "https://khanacademy.org/probability",
+            "tags": ["Basic Probability"],
+            "description": "Short desc",
+            "status": status,
+        }
+
+    def _make_col(self, oid, status="READY"):
+        doc = self._make_doc(oid, status)
+        col = MagicMock()
+        col.find_one.return_value = doc
+        return col, doc
+
+    def test_returns_none_for_invalid_id(self):
+        col = MagicMock()
+        result = explore_link(col, "not-an-objectid", MagicMock(), set())
+        assert result is None
+        col.find_one.assert_not_called()
+
+    def test_returns_none_for_rejected_link(self):
+        oid = ObjectId()
+        col, _ = self._make_col(oid, status="REJECTED")
+        result = explore_link(col, str(oid), MagicMock(), set())
+        assert result is None
+        col.update_one.assert_not_called()
+
+    def test_updates_description_when_page_returns_content(self):
+        oid = ObjectId()
+        col, original_doc = self._make_col(oid)
+        updated_doc = {**original_doc, "description": "Rich fetched description", "last_error_type": None}
+        col.find_one.side_effect = [original_doc, updated_doc]
+
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Rich fetched description", 200)), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            result = explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
+
+        update_args = col.update_one.call_args[0][1]["$set"]
+        assert update_args["description"] == "Rich fetched description"
+        assert result is not None
+
+    def test_does_not_overwrite_description_when_page_returns_empty(self):
+        """WAF-blocked or otherwise metadata-less pages should not wipe the stored description."""
+        oid = ObjectId()
+        col, original_doc = self._make_col(oid)
+        col.find_one.side_effect = [original_doc, original_doc]
+
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "", 403)), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
+
+        update_args = col.update_one.call_args[0][1]["$set"]
+        assert "description" not in update_args
+
+    def test_ready_link_demoted_when_judge_says_irrelevant(self):
+        oid = ObjectId()
+        col, original_doc = self._make_col(oid, status="READY")
+        demoted_doc = {**original_doc, "status": "NOT_READY"}
+        col.find_one.side_effect = [original_doc, demoted_doc]
+
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Better desc", 200)), \
+             patch("app.services.link_health.is_relevant", return_value=(False, "irrelevant")):
+            result = explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
+
+        update_args = col.update_one.call_args[0][1]["$set"]
+        assert update_args["status"] == "NOT_READY"
+        assert update_args["active"] is False
+        assert update_args["last_error_type"] == "irrelevant"
+
+    def test_not_ready_link_promoted_to_needs_review(self):
+        oid = ObjectId()
+        col, original_doc = self._make_col(oid, status="NOT_READY")
+        promoted_doc = {**original_doc, "status": "NEEDS_REVIEW"}
+        col.find_one.side_effect = [original_doc, promoted_doc]
+
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Good content", 200)), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            result = explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
+
+        update_args = col.update_one.call_args[0][1]["$set"]
+        assert update_args["status"] == "NEEDS_REVIEW"
+        assert update_args["last_error_type"] is None
+
+    def test_ready_link_stays_ready_when_judge_approves(self):
+        oid = ObjectId()
+        col, original_doc = self._make_col(oid, status="READY")
+        col.find_one.side_effect = [original_doc, original_doc]
+
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Good content", 200)), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
+
+        update_args = col.update_one.call_args[0][1]["$set"]
+        assert "status" not in update_args
+        assert update_args.get("last_error_type") is None
+
+    def test_records_http_code(self):
+        oid = ObjectId()
+        col, original_doc = self._make_col(oid)
+        col.find_one.side_effect = [original_doc, original_doc]
+
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Desc", 200)), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            explore_link(col, str(oid), MagicMock(), set())
+
+        update_args = col.update_one.call_args[0][1]["$set"]
+        assert update_args["last_http_code"] == 200
 
 
 # ── update_knowledge_link — status not overwritten ────────────────────────────

--- a/backend/tests/test_link_health_service.py
+++ b/backend/tests/test_link_health_service.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.services.link_health import (
     fetch_with_retries,
+    fetch_page_metadata,
     llm_judges_relevant,
     is_relevant,
     run_health_check,
@@ -155,6 +156,80 @@ class TestFetchWithRetries:
         assert ok is True  # fail-open: don't penalize protected/unknown sites
         assert code is None
         assert error is None
+
+
+# ── fetch_page_metadata ───────────────────────────────────────────────────────
+
+class TestFetchPageMetadata:
+    def _mock_resp(self, html: str, status: int = 200, content_type: str = "text/html; charset=utf-8"):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.text = html
+        resp.headers = {"content-type": content_type}
+        return resp
+
+    def test_extracts_og_description(self):
+        html = '<meta property="og:description" content="OG description here">'
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            title, desc, code = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert desc == "OG description here"
+        assert code == 200
+
+    def test_og_description_takes_priority_over_meta_name(self):
+        html = (
+            '<meta name="description" content="Fallback">'
+            '<meta property="og:description" content="OG wins">'
+        )
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            _, desc, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert desc == "OG wins"
+
+    def test_falls_back_to_meta_name_description(self):
+        html = '<meta name="description" content="Fallback description">'
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            _, desc, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert desc == "Fallback description"
+
+    def test_extracts_og_title(self):
+        html = '<meta property="og:title" content="Page Title">'
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            title, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert title == "Page Title"
+
+    def test_falls_back_to_title_tag(self):
+        html = "<title>HTML Title Tag</title>"
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            title, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert title == "HTML Title Tag"
+
+    def test_handles_content_attribute_before_property(self):
+        """meta tags sometimes have content= before property= — both orderings must work."""
+        html = '<meta content="Reversed content" property="og:description">'
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            _, desc, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert desc == "Reversed content"
+
+    def test_returns_empty_for_non_html_content_type(self):
+        resp = self._mock_resp("binary content", content_type="application/pdf")
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(resp)):
+            title, desc, code = fetch_page_metadata("https://example.com/doc.pdf", timeout=5)
+        assert title == "" and desc == "" and code == 200
+
+    def test_bot_blocked_returns_empty_metadata(self):
+        """403 (WAF block) is reachable for fetch_with_retries but yields no parseable HTML."""
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp("", status=403))):
+            title, desc, code = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert title == "" and desc == "" and code == 403
+
+    def test_exception_returns_empty_and_none_code(self):
+        mock_client = MagicMock()
+        mock_client.get.side_effect = Exception("connection failed")
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=mock_client)
+        ctx.__exit__ = MagicMock(return_value=False)
+        with patch("app.services.link_health.httpx.Client", return_value=ctx):
+            title, desc, code = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert title == "" and desc == "" and code is None
 
 
 # ── llm_judges_relevant ───────────────────────────────────────────────────────

--- a/frontend/pages/links_panel.tsx
+++ b/frontend/pages/links_panel.tsx
@@ -90,6 +90,7 @@ export default function LinkPanelPage() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [approvingId, setApprovingId] = useState<string | null>(null);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
+  const [exploringId, setExploringId] = useState<string | null>(null);
 
   // health check trigger
   const [healthChecking, setHealthChecking] = useState(false);
@@ -257,6 +258,19 @@ export default function LinkPanelPage() {
       alert("Failed to reject link.");
     } finally {
       setRejectingId(null);
+    }
+  }
+
+  async function exploreLink(id: string) {
+    setExploringId(id);
+    try {
+      const updated = await apiFetch<KnowledgeLink>(`/api/knowledge-links/${id}/explore`, { method: "POST" });
+      setLinks((prev) => prev.map((x) => (x.id === id ? updated : x)));
+    } catch (e) {
+      console.error(e);
+      alert("Failed to explore link.");
+    } finally {
+      setExploringId(null);
     }
   }
 
@@ -574,6 +588,14 @@ export default function LinkPanelPage() {
                                 >
                                   {rejectingId === link.id ? "Rejecting…" : "Reject"}
                                 </button>
+                                <button
+                                  type="button"
+                                  onClick={() => exploreLink(link.id)}
+                                  disabled={exploringId === link.id}
+                                  className="px-2 py-1 rounded border border-purple-300 bg-white text-purple-700 hover:bg-purple-50 disabled:opacity-60"
+                                >
+                                  {exploringId === link.id ? "Exploring…" : "Explore"}
+                                </button>
                               </>
                             )}
 
@@ -595,6 +617,14 @@ export default function LinkPanelPage() {
                                 >
                                   {deletingId === link.id ? "Deleting…" : "Delete"}
                                 </button>
+                                <button
+                                  type="button"
+                                  onClick={() => exploreLink(link.id)}
+                                  disabled={exploringId === link.id}
+                                  className="px-2 py-1 rounded border border-purple-300 bg-white text-purple-700 hover:bg-purple-50 disabled:opacity-60"
+                                >
+                                  {exploringId === link.id ? "Exploring…" : "Explore"}
+                                </button>
                               </>
                             )}
 
@@ -614,6 +644,14 @@ export default function LinkPanelPage() {
                                   className="px-2 py-1 rounded border border-red-300 bg-white text-red-600 hover:bg-red-50 disabled:opacity-60"
                                 >
                                   {deletingId === link.id ? "Deleting…" : "Delete"}
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => exploreLink(link.id)}
+                                  disabled={exploringId === link.id}
+                                  className="px-2 py-1 rounded border border-purple-300 bg-white text-purple-700 hover:bg-purple-50 disabled:opacity-60"
+                                >
+                                  {exploringId === link.id ? "Exploring…" : "Explore"}
                                 </button>
                               </>
                             )}


### PR DESCRIPTION
## Summary

Admins can now click Explore on any non-rejected link to have the system fetch the live page, extract a richer description from its HTML meta tags (og:description, meta name=description, og:title, <title>), update the stored entry, and re-run the LLM relevance judge — fixing cases where manually-entered links had short or vague descriptions that caused inaccurate AI judgments.