### PR TITLE
feat(explore): add article extraction and confirm-before-save flow

### DIFF
--- a/backend/app/api/knowledge_links.py
+++ b/backend/app/api/knowledge_links.py
@@ -9,6 +9,8 @@ from ..schemas.knowledge_link import (
     KnowledgeLinkCreate,
     KnowledgeLinkUpdate,
     KnowledgeLinkPublic,
+    ExplorePreview,
+    ExploreApply,
 )
 from ..schemas.user import UserPublic
 from ..api.auth import get_current_user
@@ -22,6 +24,7 @@ from ..services.knowledge_links import (
     approve_link,
     reject_link,
     explore_link,
+    apply_explore,
 )
 
 router = APIRouter(prefix="/knowledge-links", tags=["knowledge-links"])
@@ -149,14 +152,15 @@ def approve_knowledge_link(
     return result
 
 
-@router.post("/{link_id}/explore", response_model=KnowledgeLinkPublic)
+@router.post("/{link_id}/explore", response_model=ExplorePreview)
 def explore_knowledge_link(
     link_id: str,
     request: Request,
     user: UserPublic = Depends(require_admin),
 ):
-    """Fetch the live page, update title/description from HTML meta tags, re-run the
-    relevance judge with the enriched content, and return the updated link state."""
+    """Fetch the live page and return a preview (proposed title, description, article
+    excerpt, and relevance verdict) WITHOUT saving anything. The admin reviews and
+    calls /explore/apply to commit."""
     links = get_knowledge_links_collection(request.app.state.db)
     openai_client = OpenAI(
         api_key=os.getenv("UF_OPENAI_API_KEY"),
@@ -169,10 +173,36 @@ def explore_knowledge_link(
         request.app.state.allowlist_cache,
         timeout=request.app.state.settings.LINK_REQUEST_TIMEOUT,
     )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Link not found or is tombstoned")
+    return result
+
+
+@router.post("/{link_id}/explore/apply", response_model=KnowledgeLinkPublic)
+def apply_explore_knowledge_link(
+    link_id: str,
+    data: ExploreApply,
+    request: Request,
+    user: UserPublic = Depends(require_admin),
+):
+    """Save the admin-confirmed title/description, re-run the relevance judge, and
+    return the updated link state."""
+    links = get_knowledge_links_collection(request.app.state.db)
+    openai_client = OpenAI(
+        api_key=os.getenv("UF_OPENAI_API_KEY"),
+        base_url=os.getenv("UF_OPENAI_BASE_URL", "https://api.ai.it.ufl.edu"),
+    )
+    result = apply_explore(
+        links,
+        link_id,
+        data.title,
+        data.description,
+        openai_client,
+        request.app.state.allowlist_cache,
+    )
     if not result:
         raise HTTPException(status_code=404, detail="Link not found or is tombstoned")
 
-    # Keep chatbot cache consistent with any status changes
     request.app.state.knowledge_links = [
         l for l in request.app.state.knowledge_links if l["id"] != link_id
     ]

--- a/backend/app/schemas/knowledge_link.py
+++ b/backend/app/schemas/knowledge_link.py
@@ -27,6 +27,22 @@ class KnowledgeLinkUpdate(KnowledgeLinkBase):
     pass
 
 
+class ExplorePreview(BaseModel):
+    """Returned by POST /explore before the admin confirms. Nothing is saved yet."""
+    proposed_title: str
+    proposed_description: str
+    article_excerpt: str
+    http_code: Optional[int] = None
+    relevant: bool
+    relevance_reason: Optional[str] = None
+
+
+class ExploreApply(BaseModel):
+    """Body for POST /explore/apply — the title/description the admin confirmed."""
+    title: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+
+
 class KnowledgeLinkPublic(BaseModel):
     id: str
     title: str

--- a/backend/app/services/knowledge_links.py
+++ b/backend/app/services/knowledge_links.py
@@ -8,6 +8,7 @@ from ..schemas.knowledge_link import (
     KnowledgeLinkCreate,
     KnowledgeLinkUpdate,
     KnowledgeLinkPublic,
+    ExplorePreview,
     LinkStatus,
 )
 
@@ -177,14 +178,11 @@ def explore_link(
     openai_client,
     allowlist_cache: set,
     timeout: int = 10,
-) -> Optional[KnowledgeLinkPublic]:
-    """Fetch the link's live page, update its stored title/description from HTML meta
-    tags, re-run the relevance judge with the enriched content, and return the updated
-    document.
+) -> Optional[ExplorePreview]:
+    """Fetch the link's live page and return a preview of what would change — nothing
+    is written to the database.  The admin reviews the proposed title/description (and
+    the raw article excerpt as an alternative) then calls apply_explore to commit.
 
-    Status transitions follow the same rules as run_health_check:
-      READY + fails relevance  → NOT_READY
-      NOT_READY + passes relevance → NEEDS_REVIEW
     Returns None for REJECTED links or invalid IDs.
     """
     from .link_health import fetch_page_metadata, is_relevant
@@ -197,24 +195,58 @@ def explore_link(
 
     url = doc.get("url", "")
     tag = doc["tags"][0] if doc.get("tags") else "Other"
+
+    fetched_title, fetched_description, article_excerpt, http_code = fetch_page_metadata(url, timeout=timeout)
+
+    # Judge relevance using the best available content (meta desc preferred, excerpt
+    # as fallback, existing description as last resort so we always get a verdict).
+    judge_title = fetched_title or doc.get("title", "")
+    judge_description = fetched_description or article_excerpt or doc.get("description", "")
+    link_dict = {"url": url, "title": judge_title, "description": judge_description}
+    relevant, relevance_reason = is_relevant(tag, link_dict, openai_client, allowlist_cache)
+
+    return ExplorePreview(
+        proposed_title=fetched_title,
+        proposed_description=fetched_description,
+        article_excerpt=article_excerpt,
+        http_code=http_code,
+        relevant=relevant,
+        relevance_reason=relevance_reason,
+    )
+
+
+def apply_explore(
+    links: Collection,
+    link_id: str,
+    new_title: str,
+    new_description: str,
+    openai_client,
+    allowlist_cache: set,
+) -> Optional[KnowledgeLinkPublic]:
+    """Save the admin-confirmed title/description, re-run the relevance judge, apply
+    the same status transitions as run_health_check, and return the updated document.
+
+    Returns None for REJECTED links or invalid IDs.
+    """
+    from .link_health import is_relevant
+
+    if not ObjectId.is_valid(link_id):
+        return None
+    doc = links.find_one({"_id": ObjectId(link_id)})
+    if not doc or doc.get("status") == "REJECTED":
+        return None
+
+    url = doc.get("url", "")
+    tag = doc["tags"][0] if doc.get("tags") else "Other"
     now = datetime.now(timezone.utc)
 
-    fetched_title, fetched_description, http_code = fetch_page_metadata(url, timeout=timeout)
+    title = new_title.strip()
+    description = new_description.strip()
 
-    update: dict = {"last_checked": now, "updated_at": now}
-    if http_code is not None:
-        update["last_http_code"] = http_code
-
-    # Only overwrite stored fields when the page returned real content
-    new_title = fetched_title if fetched_title else doc.get("title", "")
-    new_description = fetched_description if fetched_description else doc.get("description", "")
-    if fetched_title:
-        update["title"] = fetched_title
-    if fetched_description:
-        update["description"] = fetched_description
-
-    link_dict = {"url": url, "title": new_title, "description": new_description}
+    link_dict = {"url": url, "title": title, "description": description}
     relevant, relevance_reason = is_relevant(tag, link_dict, openai_client, allowlist_cache)
+
+    update: dict = {"title": title, "description": description, "last_checked": now, "updated_at": now}
 
     current_status = doc.get("status", "READY")
     if current_status == "READY" and not relevant:

--- a/backend/app/services/link_health.py
+++ b/backend/app/services/link_health.py
@@ -45,6 +45,19 @@ _BROWSER_HEADERS = {
 _BOT_BLOCK_STATUS_CODES = {401, 402, 403}
 
 _RE_TITLE_TAG = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_RE_HTML_TAG = re.compile(r"<[^>]+>")
+_RE_WHITESPACE = re.compile(r"\s+")
+_RE_PARA = re.compile(r"<p\b[^>]*>(.*?)</p>", re.IGNORECASE | re.DOTALL)
+
+# Content-area wrappers tried in order before falling back to the full page.
+_CONTENT_AREA_PATTERNS = [
+    re.compile(r"<article\b[^>]*>(.*?)</article>", re.IGNORECASE | re.DOTALL),
+    re.compile(r"<main\b[^>]*>(.*?)</main>", re.IGNORECASE | re.DOTALL),
+    re.compile(
+        r'<div\b[^>]*\bclass=["\'][^"\']*(?:content|article|post|entry|body)[^"\']*["\'][^>]*>(.*?)</div>',
+        re.IGNORECASE | re.DOTALL,
+    ),
+]
 
 
 def _meta_content(html: str, attr: str, value: str) -> str:
@@ -64,26 +77,51 @@ def _meta_content(html: str, attr: str, value: str) -> str:
     return m.group(1) if m else ""
 
 
+def _first_article_paragraph(html: str, min_length: int = 80) -> str:
+    """Return the first meaningful <p> text from a semantic content area.
+
+    Tries <article>, <main>, and common content div classes in order, then falls back
+    to the full page. Strips tags, collapses whitespace, and caps at 500 chars.
+    min_length filters out nav items, captions, and other short inline text.
+    """
+    region = html
+    for pattern in _CONTENT_AREA_PATTERNS:
+        m = pattern.search(html)
+        if m:
+            region = m.group(1)
+            break
+
+    for p_match in _RE_PARA.finditer(region):
+        text = _RE_HTML_TAG.sub("", p_match.group(1))
+        text = _RE_WHITESPACE.sub(" ", text).strip()
+        if len(text) >= min_length:
+            return text[:500]
+    return ""
+
+
 def fetch_page_metadata(
     url: str,
     timeout: int = 10,
-) -> tuple[str, str, Optional[int]]:
-    """Fetch url and extract (title, description, http_code) from its HTML meta tags.
+) -> tuple[str, str, str, Optional[int]]:
+    """Fetch url and extract (title, description, article_excerpt, http_code).
 
-    Returns ("", "", http_code) when unreachable, non-HTML, or metadata is absent.
-    Bot-blocked responses (401/402/403) return ("", "", http_code) without parsing.
+    description  — best meta tag description (og:description or meta name=description)
+    article_excerpt — first meaningful paragraph from article/main body content;
+                      useful as a fallback when the meta description is generic.
+    Returns ("", "", "", http_code) when unreachable or non-HTML.
+    Bot-blocked responses (401/402/403) return empty strings without parsing.
     """
     try:
         with httpx.Client(timeout=timeout, follow_redirects=True) as client:
             resp = client.get(url, headers=_BROWSER_HEADERS)
         http_code = resp.status_code
         if resp.status_code != 200:
-            return "", "", http_code
+            return "", "", "", http_code
         if "html" not in resp.headers.get("content-type", "").lower():
-            return "", "", http_code
-        html = resp.text[:51200]  # first 50 KB — meta tags are always in <head>
+            return "", "", "", http_code
+        html = resp.text[:51200]  # first 50 KB — meta tags and article intros are in <head>/<body>
     except Exception:
-        return "", "", None
+        return "", "", "", None
 
     _title_m = _RE_TITLE_TAG.search(html)
     title = (
@@ -95,7 +133,8 @@ def fetch_page_metadata(
         _meta_content(html, "property", "og:description")
         or _meta_content(html, "name", "description")
     )
-    return title.strip(), description.strip(), http_code
+    excerpt = _first_article_paragraph(html)
+    return title.strip(), description.strip(), excerpt, http_code
 
 
 def fetch_with_retries(

--- a/backend/tests/test_knowledge_links_service.py
+++ b/backend/tests/test_knowledge_links_service.py
@@ -12,6 +12,7 @@ from app.services.knowledge_links import (
     approve_link,
     reject_link,
     explore_link,
+    apply_explore,
     reload_knowledge_links_cache,
     list_knowledge_links_by_status,
     update_knowledge_link,
@@ -268,7 +269,7 @@ class TestListKnowledgeLinksByStatus:
         assert results[0].status == LinkStatus.READY
 
 
-# ── explore_link ──────────────────────────────────────────────────────────────
+# ── explore_link (preview — no DB writes) ────────────────────────────────────
 
 class TestExploreLink:
     def _make_doc(self, oid, status="READY"):
@@ -298,60 +299,107 @@ class TestExploreLink:
         col, _ = self._make_col(oid, status="REJECTED")
         result = explore_link(col, str(oid), MagicMock(), set())
         assert result is None
+
+    def test_does_not_write_to_db(self):
+        """explore_link is a preview-only operation — it must not touch the database."""
+        oid = ObjectId()
+        col, _ = self._make_col(oid)
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("T", "D", "E", 200)), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            explore_link(col, str(oid), MagicMock(), set())
         col.update_one.assert_not_called()
 
-    def test_updates_description_when_page_returns_content(self):
+    def test_returns_explore_preview_with_fetched_content(self):
+        oid = ObjectId()
+        col, _ = self._make_col(oid)
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("Fetched Title", "Fetched desc", "Article para", 200)), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            result = explore_link(col, str(oid), MagicMock(), set())
+        assert result.proposed_title == "Fetched Title"
+        assert result.proposed_description == "Fetched desc"
+        assert result.article_excerpt == "Article para"
+        assert result.http_code == 200
+
+    def test_relevant_flag_reflects_judge_verdict(self):
+        oid = ObjectId()
+        col, _ = self._make_col(oid)
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Some desc", "", 200)), \
+             patch("app.services.link_health.is_relevant", return_value=(False, "irrelevant")):
+            result = explore_link(col, str(oid), MagicMock(), set())
+        assert result.relevant is False
+        assert result.relevance_reason == "irrelevant"
+
+    def test_falls_back_to_stored_description_for_judge_when_fetch_empty(self):
+        """When the page returns nothing useful, judge still runs using the stored description."""
+        oid = ObjectId()
+        col, doc = self._make_col(oid)
+        mock_relevant = MagicMock(return_value=(True, None))
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "", "", 403)), \
+             patch("app.services.link_health.is_relevant", mock_relevant):
+            explore_link(col, str(oid), MagicMock(), set())
+        _, kwargs = mock_relevant.call_args
+        link_arg = mock_relevant.call_args[0][1]
+        assert link_arg["description"] == doc["description"]
+
+
+# ── apply_explore (saves confirmed content) ───────────────────────────────────
+
+class TestApplyExplore:
+    def _make_doc(self, oid, status="READY"):
+        return {
+            "_id": oid,
+            "title": "Old Title",
+            "url": "https://khanacademy.org/probability",
+            "tags": ["Basic Probability"],
+            "description": "Old short desc",
+            "status": status,
+        }
+
+    def _make_col(self, oid, status="READY"):
+        doc = self._make_doc(oid, status)
+        col = MagicMock()
+        col.find_one.return_value = doc
+        return col, doc
+
+    def test_returns_none_for_invalid_id(self):
+        col = MagicMock()
+        result = apply_explore(col, "bad-id", "T", "D", MagicMock(), set())
+        assert result is None
+
+    def test_returns_none_for_rejected_link(self):
+        oid = ObjectId()
+        col, _ = self._make_col(oid, status="REJECTED")
+        result = apply_explore(col, str(oid), "T", "D", MagicMock(), set())
+        assert result is None
+        col.update_one.assert_not_called()
+
+    def test_saves_new_title_and_description(self):
         oid = ObjectId()
         col, original_doc = self._make_col(oid)
-        updated_doc = {**original_doc, "description": "Rich fetched description", "last_error_type": None}
+        updated_doc = {**original_doc, "title": "New Title", "description": "Better description"}
         col.find_one.side_effect = [original_doc, updated_doc]
-
-        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Rich fetched description", 200)), \
-             patch("app.services.link_health.is_relevant", return_value=(True, None)):
-            result = explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
-
+        with patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            apply_explore(col, str(oid), "New Title", "Better description", MagicMock(), set())
         update_args = col.update_one.call_args[0][1]["$set"]
-        assert update_args["description"] == "Rich fetched description"
-        assert result is not None
-
-    def test_does_not_overwrite_description_when_page_returns_empty(self):
-        """WAF-blocked or otherwise metadata-less pages should not wipe the stored description."""
-        oid = ObjectId()
-        col, original_doc = self._make_col(oid)
-        col.find_one.side_effect = [original_doc, original_doc]
-
-        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "", 403)), \
-             patch("app.services.link_health.is_relevant", return_value=(True, None)):
-            explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
-
-        update_args = col.update_one.call_args[0][1]["$set"]
-        assert "description" not in update_args
+        assert update_args["title"] == "New Title"
+        assert update_args["description"] == "Better description"
 
     def test_ready_link_demoted_when_judge_says_irrelevant(self):
         oid = ObjectId()
         col, original_doc = self._make_col(oid, status="READY")
-        demoted_doc = {**original_doc, "status": "NOT_READY"}
-        col.find_one.side_effect = [original_doc, demoted_doc]
-
-        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Better desc", 200)), \
-             patch("app.services.link_health.is_relevant", return_value=(False, "irrelevant")):
-            result = explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
-
+        col.find_one.side_effect = [original_doc, {**original_doc, "status": "NOT_READY"}]
+        with patch("app.services.link_health.is_relevant", return_value=(False, "irrelevant")):
+            apply_explore(col, str(oid), "T", "D", MagicMock(), set())
         update_args = col.update_one.call_args[0][1]["$set"]
         assert update_args["status"] == "NOT_READY"
-        assert update_args["active"] is False
         assert update_args["last_error_type"] == "irrelevant"
 
     def test_not_ready_link_promoted_to_needs_review(self):
         oid = ObjectId()
         col, original_doc = self._make_col(oid, status="NOT_READY")
-        promoted_doc = {**original_doc, "status": "NEEDS_REVIEW"}
-        col.find_one.side_effect = [original_doc, promoted_doc]
-
-        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Good content", 200)), \
-             patch("app.services.link_health.is_relevant", return_value=(True, None)):
-            result = explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
-
+        col.find_one.side_effect = [original_doc, {**original_doc, "status": "NEEDS_REVIEW"}]
+        with patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            apply_explore(col, str(oid), "T", "Good description", MagicMock(), set())
         update_args = col.update_one.call_args[0][1]["$set"]
         assert update_args["status"] == "NEEDS_REVIEW"
         assert update_args["last_error_type"] is None
@@ -360,26 +408,11 @@ class TestExploreLink:
         oid = ObjectId()
         col, original_doc = self._make_col(oid, status="READY")
         col.find_one.side_effect = [original_doc, original_doc]
-
-        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Good content", 200)), \
-             patch("app.services.link_health.is_relevant", return_value=(True, None)):
-            explore_link(col, str(oid), MagicMock(), {"khanacademy.org"})
-
+        with patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            apply_explore(col, str(oid), "T", "D", MagicMock(), set())
         update_args = col.update_one.call_args[0][1]["$set"]
         assert "status" not in update_args
         assert update_args.get("last_error_type") is None
-
-    def test_records_http_code(self):
-        oid = ObjectId()
-        col, original_doc = self._make_col(oid)
-        col.find_one.side_effect = [original_doc, original_doc]
-
-        with patch("app.services.link_health.fetch_page_metadata", return_value=("", "Desc", 200)), \
-             patch("app.services.link_health.is_relevant", return_value=(True, None)):
-            explore_link(col, str(oid), MagicMock(), set())
-
-        update_args = col.update_one.call_args[0][1]["$set"]
-        assert update_args["last_http_code"] == 200
 
 
 # ── update_knowledge_link — status not overwritten ────────────────────────────

--- a/backend/tests/test_link_health_service.py
+++ b/backend/tests/test_link_health_service.py
@@ -9,6 +9,7 @@ import pytest
 from app.services.link_health import (
     fetch_with_retries,
     fetch_page_metadata,
+    _first_article_paragraph,
     llm_judges_relevant,
     is_relevant,
     run_health_check,
@@ -171,7 +172,7 @@ class TestFetchPageMetadata:
     def test_extracts_og_description(self):
         html = '<meta property="og:description" content="OG description here">'
         with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
-            title, desc, code = fetch_page_metadata("https://example.com/page", timeout=5)
+            title, desc, excerpt, code = fetch_page_metadata("https://example.com/page", timeout=5)
         assert desc == "OG description here"
         assert code == 200
 
@@ -181,45 +182,51 @@ class TestFetchPageMetadata:
             '<meta property="og:description" content="OG wins">'
         )
         with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
-            _, desc, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+            _, desc, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
         assert desc == "OG wins"
 
     def test_falls_back_to_meta_name_description(self):
         html = '<meta name="description" content="Fallback description">'
         with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
-            _, desc, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+            _, desc, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
         assert desc == "Fallback description"
 
     def test_extracts_og_title(self):
         html = '<meta property="og:title" content="Page Title">'
         with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
-            title, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+            title, _, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
         assert title == "Page Title"
 
     def test_falls_back_to_title_tag(self):
         html = "<title>HTML Title Tag</title>"
         with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
-            title, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+            title, _, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
         assert title == "HTML Title Tag"
+
+    def test_extracts_article_excerpt(self):
+        html = "<article><p>Short.</p><p>Probability is the mathematical study of uncertainty and random events, covering sample spaces, events, and axioms of probability theory in great detail.</p></article>"
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            _, _, excerpt, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert "Probability" in excerpt
 
     def test_handles_content_attribute_before_property(self):
         """meta tags sometimes have content= before property= — both orderings must work."""
         html = '<meta content="Reversed content" property="og:description">'
         with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
-            _, desc, _ = fetch_page_metadata("https://example.com/page", timeout=5)
+            _, desc, _, _ = fetch_page_metadata("https://example.com/page", timeout=5)
         assert desc == "Reversed content"
 
     def test_returns_empty_for_non_html_content_type(self):
         resp = self._mock_resp("binary content", content_type="application/pdf")
         with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(resp)):
-            title, desc, code = fetch_page_metadata("https://example.com/doc.pdf", timeout=5)
-        assert title == "" and desc == "" and code == 200
+            title, desc, excerpt, code = fetch_page_metadata("https://example.com/doc.pdf", timeout=5)
+        assert title == "" and desc == "" and excerpt == "" and code == 200
 
     def test_bot_blocked_returns_empty_metadata(self):
         """403 (WAF block) is reachable for fetch_with_retries but yields no parseable HTML."""
         with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp("", status=403))):
-            title, desc, code = fetch_page_metadata("https://example.com/page", timeout=5)
-        assert title == "" and desc == "" and code == 403
+            title, desc, excerpt, code = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert title == "" and desc == "" and excerpt == "" and code == 403
 
     def test_exception_returns_empty_and_none_code(self):
         mock_client = MagicMock()
@@ -228,8 +235,47 @@ class TestFetchPageMetadata:
         ctx.__enter__ = MagicMock(return_value=mock_client)
         ctx.__exit__ = MagicMock(return_value=False)
         with patch("app.services.link_health.httpx.Client", return_value=ctx):
-            title, desc, code = fetch_page_metadata("https://example.com/page", timeout=5)
-        assert title == "" and desc == "" and code is None
+            title, desc, excerpt, code = fetch_page_metadata("https://example.com/page", timeout=5)
+        assert title == "" and desc == "" and excerpt == "" and code is None
+
+
+# ── _first_article_paragraph ──────────────────────────────────────────────────
+
+class TestFirstArticleParagraph:
+    LONG = "Probability is the mathematical study of random events and uncertainty, covering sample spaces, axioms, and distributions."
+
+    def test_extracts_from_article_tag(self):
+        html = f"<article><p>Short.</p><p>{self.LONG}</p></article>"
+        assert self.LONG in _first_article_paragraph(html)
+
+    def test_extracts_from_main_tag(self):
+        html = f"<main><p>{self.LONG}</p></main>"
+        assert self.LONG in _first_article_paragraph(html)
+
+    def test_skips_short_paragraphs(self):
+        html = f"<article><p>Nav item.</p><p>Also short.</p><p>{self.LONG}</p></article>"
+        result = _first_article_paragraph(html)
+        assert result == self.LONG[:500]
+
+    def test_strips_html_tags(self):
+        html = f"<article><p>{self.LONG} <a href='/'>link</a> text</p></article>"
+        result = _first_article_paragraph(html)
+        assert "<a" not in result
+        assert "link" in result
+
+    def test_caps_at_500_chars(self):
+        long_text = "A" * 600
+        html = f"<article><p>{long_text}</p></article>"
+        result = _first_article_paragraph(html)
+        assert len(result) == 500
+
+    def test_returns_empty_when_no_long_paragraph(self):
+        html = "<article><p>Short.</p><p>Also short.</p></article>"
+        assert _first_article_paragraph(html) == ""
+
+    def test_falls_back_to_full_page_when_no_semantic_wrapper(self):
+        html = f"<html><body><p>{self.LONG}</p></body></html>"
+        assert self.LONG in _first_article_paragraph(html)
 
 
 # ── llm_judges_relevant ───────────────────────────────────────────────────────

--- a/frontend/pages/links_panel.tsx
+++ b/frontend/pages/links_panel.tsx
@@ -30,6 +30,19 @@ type KnowledgeLink = {
 
 type ActiveTab = "all" | "review" | "dead";
 
+type ExplorePreview = {
+  linkId: string;
+  proposedTitle: string;
+  proposedDescription: string;
+  articleExcerpt: string;
+  httpCode: number | null;
+  relevant: boolean;
+  relevanceReason: string | null;
+  // editable drafts shown in the confirmation card
+  draftTitle: string;
+  draftDescription: string;
+};
+
 function StatusBadge({ status }: { status: LinkStatus }) {
   const cfg: Record<LinkStatus, { label: string; cls: string }> = {
     READY:        { label: "Ready",          cls: "bg-green-100 text-green-800 border-green-200" },
@@ -91,6 +104,8 @@ export default function LinkPanelPage() {
   const [approvingId, setApprovingId] = useState<string | null>(null);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
   const [exploringId, setExploringId] = useState<string | null>(null);
+  const [explorePreview, setExplorePreview] = useState<ExplorePreview | null>(null);
+  const [applyingExplore, setApplyingExplore] = useState(false);
 
   // health check trigger
   const [healthChecking, setHealthChecking] = useState(false);
@@ -264,13 +279,56 @@ export default function LinkPanelPage() {
   async function exploreLink(id: string) {
     setExploringId(id);
     try {
-      const updated = await apiFetch<KnowledgeLink>(`/api/knowledge-links/${id}/explore`, { method: "POST" });
-      setLinks((prev) => prev.map((x) => (x.id === id ? updated : x)));
+      const data = await apiFetch<{
+        proposed_title: string;
+        proposed_description: string;
+        article_excerpt: string;
+        http_code: number | null;
+        relevant: boolean;
+        relevance_reason: string | null;
+      }>(`/api/knowledge-links/${id}/explore`, { method: "POST" });
+
+      const bestDescription = data.proposed_description || data.article_excerpt || "";
+      setExplorePreview({
+        linkId: id,
+        proposedTitle: data.proposed_title,
+        proposedDescription: data.proposed_description,
+        articleExcerpt: data.article_excerpt,
+        httpCode: data.http_code,
+        relevant: data.relevant,
+        relevanceReason: data.relevance_reason,
+        draftTitle: data.proposed_title || links.find((l) => l.id === id)?.title || "",
+        draftDescription: bestDescription || links.find((l) => l.id === id)?.description || "",
+      });
     } catch (e) {
       console.error(e);
-      alert("Failed to explore link.");
+      alert("Failed to fetch page preview.");
     } finally {
       setExploringId(null);
+    }
+  }
+
+  async function applyExplore() {
+    if (!explorePreview || applyingExplore) return;
+    setApplyingExplore(true);
+    try {
+      const updated = await apiFetch<KnowledgeLink>(
+        `/api/knowledge-links/${explorePreview.linkId}/explore/apply`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            title: explorePreview.draftTitle,
+            description: explorePreview.draftDescription,
+          }),
+        }
+      );
+      setLinks((prev) => prev.map((x) => (x.id === explorePreview.linkId ? updated : x)));
+      setExplorePreview(null);
+    } catch (e) {
+      console.error(e);
+      alert("Failed to apply explore changes.");
+    } finally {
+      setApplyingExplore(false);
     }
   }
 
@@ -681,11 +739,77 @@ export default function LinkPanelPage() {
                         )}
                       </div>
                     </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
+                  {/* Explore confirmation panel */}
+                  {explorePreview?.linkId === link.id && (
+                    <div className="mt-3 rounded-lg border border-purple-200 bg-purple-50 p-4 space-y-3">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-semibold text-purple-800 uppercase tracking-wide">Explore Preview</span>
+                        <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold border ${
+                          explorePreview.relevant
+                            ? "bg-green-100 text-green-800 border-green-200"
+                            : "bg-red-100 text-red-800 border-red-200"
+                        }`}>
+                          {explorePreview.relevant ? "Relevant" : `Not relevant · ${errorTypeLabel(explorePreview.relevanceReason ?? "irrelevant")}`}
+                        </span>
+                      </div>
+
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Title</label>
+                        <input
+                          value={explorePreview.draftTitle}
+                          onChange={(e) => setExplorePreview((p) => p ? { ...p, draftTitle: e.target.value } : p)}
+                          className="w-full rounded border px-2 py-1 text-sm"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Description</label>
+                        <textarea
+                          value={explorePreview.draftDescription}
+                          onChange={(e) => setExplorePreview((p) => p ? { ...p, draftDescription: e.target.value } : p)}
+                          className="w-full rounded border px-2 py-1 text-sm"
+                          rows={4}
+                        />
+                        {explorePreview.articleExcerpt &&
+                          explorePreview.articleExcerpt !== explorePreview.draftDescription && (
+                          <div className="mt-2 rounded bg-white border border-purple-200 p-2">
+                            <p className="text-xs font-medium text-purple-700 mb-1">Alternative from article body:</p>
+                            <p className="text-xs text-gray-600 line-clamp-3">{explorePreview.articleExcerpt}</p>
+                            <button
+                              type="button"
+                              onClick={() => setExplorePreview((p) => p ? { ...p, draftDescription: p.articleExcerpt } : p)}
+                              className="mt-1 text-xs text-purple-700 underline hover:text-purple-900"
+                            >
+                              Use this instead
+                            </button>
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={applyExplore}
+                          disabled={applyingExplore || !explorePreview.draftTitle.trim() || !explorePreview.draftDescription.trim()}
+                          className="rounded-lg bg-purple-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-purple-700 disabled:opacity-60"
+                        >
+                          {applyingExplore ? "Saving…" : "Apply"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setExplorePreview(null)}
+                          className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- fetch_page_metadata now returns a 4-tuple including article_excerpt, extracted from <article>/<main> when the meta description is generic
- POST /{link_id}/explore is now preview-only (no DB writes); returns ExplorePreview with proposed title, description, excerpt, and relevance verdict
- New POST /{link_id}/explore/apply saves admin-confirmed content, re-judges relevance, and applies status transitions
- Frontend shows an inline confirmation panel with editable title/description, article excerpt alternative, and Apply/Cancel buttons before committing
- 78 tests passing (updated for 4-tuple unpacking + new apply_explore coverage)