### PR TITLE
fix(explore): clear generic meta descriptions and use URL slug as fallback

### DIFF
--- a/backend/app/services/link_health.py
+++ b/backend/app/services/link_health.py
@@ -59,6 +59,41 @@ _CONTENT_AREA_PATTERNS = [
     ),
 ]
 
+# Lowercase substrings that identify known generic site-wide meta descriptions.
+# These are useless for relevance judging and should be discarded so the system
+# falls through to the article excerpt or URL slug instead.
+_GENERIC_DESCRIPTION_FRAGMENTS = [
+    "your all-in-one learning portal",          # GeeksforGeeks
+    "a free, collaborative, example repository", # Rosetta Code
+]
+
+
+def _is_generic_description(desc: str) -> bool:
+    """Return True when desc is a known site-wide boilerplate rather than page-specific content."""
+    lower = desc.lower()
+    return any(frag in lower for frag in _GENERIC_DESCRIPTION_FRAGMENTS)
+
+
+def _url_slug_description(url: str) -> str:
+    """Humanize the last meaningful path segment of a URL into a readable string.
+
+    e.g. '.../introduction-to-divide-and-conquer-algorithm/' → 'Introduction To Divide And Conquer Algorithm'
+    Falls back to '' when no useful segment is found.
+    """
+    path = urlparse(url).path
+    segments = [s for s in path.rstrip("/").split("/") if s]
+    if not segments:
+        return ""
+    slug = segments[-1]
+    # Skip overly-generic trailing segments
+    if slug in {"index", "home", "page", "article", "post", "blog", "dsa", "maths"}:
+        slug = segments[-2] if len(segments) >= 2 else ""
+    if not slug:
+        return ""
+    text = re.sub(r"[-_]+", " ", slug).strip()
+    text = _RE_WHITESPACE.sub(" ", text)
+    return text.title()
+
 
 def _meta_content(html: str, attr: str, value: str) -> str:
     """Return the content= of the first <meta> tag that has attr=value (either attribute order)."""
@@ -133,7 +168,14 @@ def fetch_page_metadata(
         _meta_content(html, "property", "og:description")
         or _meta_content(html, "name", "description")
     )
+    # Discard site-wide boilerplate so callers fall through to a more useful signal.
+    if _is_generic_description(description):
+        description = ""
     excerpt = _first_article_paragraph(html)
+    # When JS rendering hides the article body, derive a content hint from the URL slug
+    # so the relevance judge and admin always have something meaningful to work with.
+    if not excerpt:
+        excerpt = _url_slug_description(url)
     return title.strip(), description.strip(), excerpt, http_code
 
 

--- a/backend/tests/test_link_health_service.py
+++ b/backend/tests/test_link_health_service.py
@@ -10,6 +10,8 @@ from app.services.link_health import (
     fetch_with_retries,
     fetch_page_metadata,
     _first_article_paragraph,
+    _is_generic_description,
+    _url_slug_description,
     llm_judges_relevant,
     is_relevant,
     run_health_check,
@@ -237,6 +239,73 @@ class TestFetchPageMetadata:
         with patch("app.services.link_health.httpx.Client", return_value=ctx):
             title, desc, excerpt, code = fetch_page_metadata("https://example.com/page", timeout=5)
         assert title == "" and desc == "" and excerpt == "" and code is None
+
+    def test_clears_generic_gfg_description(self):
+        """GeeksforGeeks serves a site-wide meta description that is useless for
+        relevance judging — fetch_page_metadata must discard it (return '')."""
+        html = (
+            '<meta property="og:description" content="Your All-in-One Learning Portal: '
+            'GeeksforGeeks is a comprehensive educational platform.">'
+        )
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            _, desc, _, _ = fetch_page_metadata("https://www.geeksforgeeks.org/some-article/", timeout=5)
+        assert desc == ""
+
+    def test_uses_url_slug_when_no_article_excerpt(self):
+        """When JS rendering hides article content and meta description is empty/generic,
+        the URL slug should surface as the excerpt so the judge has something useful."""
+        html = "<html><head></head><body><div>No readable paragraphs here.</div></body></html>"
+        with patch("app.services.link_health.httpx.Client", return_value=_mock_httpx_client(self._mock_resp(html))):
+            _, _, excerpt, _ = fetch_page_metadata(
+                "https://www.geeksforgeeks.org/dsa/introduction-to-divide-and-conquer-algorithm/", timeout=5
+            )
+        assert "Divide" in excerpt
+        assert "Conquer" in excerpt
+
+
+# ── _is_generic_description ───────────────────────────────────────────────────
+
+class TestIsGenericDescription:
+    def test_gfg_pattern_detected(self):
+        assert _is_generic_description(
+            "Your All-in-One Learning Portal: GeeksforGeeks is a comprehensive educational platform."
+        ) is True
+
+    def test_case_insensitive(self):
+        assert _is_generic_description("YOUR ALL-IN-ONE LEARNING PORTAL") is True
+
+    def test_page_specific_description_not_flagged(self):
+        assert _is_generic_description(
+            "Divide and Conquer is an algorithm design paradigm that breaks problems into subproblems."
+        ) is False
+
+    def test_empty_string_not_flagged(self):
+        assert _is_generic_description("") is False
+
+
+# ── _url_slug_description ─────────────────────────────────────────────────────
+
+class TestUrlSlugDescription:
+    def test_humanizes_hyphenated_slug(self):
+        result = _url_slug_description(
+            "https://www.geeksforgeeks.org/dsa/introduction-to-divide-and-conquer-algorithm/"
+        )
+        assert result == "Introduction To Divide And Conquer Algorithm"
+
+    def test_skips_generic_trailing_segment(self):
+        """When the last segment is a generic word like 'dsa', uses the segment before it."""
+        result = _url_slug_description("https://example.com/algorithms/dsa")
+        assert result == "Algorithms"
+
+    def test_underscore_separator(self):
+        result = _url_slug_description("https://example.com/probability_theory")
+        assert result == "Probability Theory"
+
+    def test_empty_for_bare_domain(self):
+        assert _url_slug_description("https://example.com/") == ""
+
+    def test_empty_for_unknown_generic_only(self):
+        assert _url_slug_description("https://example.com/index") == ""
 
 
 # ── _first_article_paragraph ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix: _is_generic_description() detects known boilerplate patterns and clears the description; _url_slug_description() humanizes the URL path slug (e.g. "introduction-to-divide-and-conquer-algorithm" → "Introduction To Divide And Conquer Algorithm") as a fallback excerpt when no real body content is extractable.