### PR TITLE
feat(explore): use Jina Reader + LLM to summarize JS-rendered pages

### DIFF
--- a/backend/app/services/knowledge_links.py
+++ b/backend/app/services/knowledge_links.py
@@ -185,7 +185,7 @@ def explore_link(
 
     Returns None for REJECTED links or invalid IDs.
     """
-    from .link_health import fetch_page_metadata, is_relevant
+    from .link_health import fetch_page_metadata, fetch_readable_content, summarize_page_content, is_relevant
 
     if not ObjectId.is_valid(link_id):
         return None
@@ -197,6 +197,16 @@ def explore_link(
     tag = doc["tags"][0] if doc.get("tags") else "Other"
 
     fetched_title, fetched_description, article_excerpt, http_code = fetch_page_metadata(url, timeout=timeout)
+
+    # When meta description is missing (was generic/absent) try fetching the full
+    # readable content via Jina Reader and summarizing it with the LLM.  This handles
+    # JS-rendered sites like GeeksforGeeks where the raw HTML carries no article text.
+    if not fetched_description:
+        readable = fetch_readable_content(url, timeout=timeout)
+        if readable:
+            fetched_description = summarize_page_content(readable, fetched_title or url, openai_client)
+            if not article_excerpt:
+                article_excerpt = readable[:500]
 
     # Judge relevance using the best available content (meta desc preferred, excerpt
     # as fallback, existing description as last resort so we always get a verdict).

--- a/backend/app/services/link_health.py
+++ b/backend/app/services/link_health.py
@@ -179,6 +179,54 @@ def fetch_page_metadata(
     return title.strip(), description.strip(), excerpt, http_code
 
 
+def fetch_readable_content(url: str, timeout: int = 15) -> str:
+    """Fetch clean readable text from a JS-rendered page via Jina Reader (r.jina.ai).
+
+    Jina renders the page with a headless browser and returns plain text, which is
+    useful when the raw HTML fetch yields no article content (e.g. GeeksforGeeks,
+    Medium, or other SPA-heavy sites). Only called during admin Explore, not health
+    checks, so the extra latency is acceptable.
+    Returns empty string on any failure.
+    """
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(
+                f"https://r.jina.ai/{url}",
+                headers={"Accept": "text/plain"},
+            )
+        if resp.status_code == 200:
+            return resp.text[:4000]
+    except Exception:
+        pass
+    return ""
+
+
+def summarize_page_content(content: str, title: str, openai_client) -> str:
+    """Ask the LLM to generate a 1-2 sentence resource description from page content.
+
+    Returns empty string on failure so callers can fall through to other signals.
+    """
+    if not content:
+        return ""
+    try:
+        prompt = (
+            "Write a concise 1-2 sentence description of the following web page for use "
+            "as an educational resource summary. Focus on the specific topic covered, not "
+            f"the website itself. Page title: '{title}'.\n\nPage content:\n{content[:3000]}"
+        )
+        model = os.getenv("UF_OPENAI_API_MODEL", "gpt-4o-mini")
+        resp = openai_client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=120,
+            temperature=0.3,
+        )
+        return (resp.choices[0].message.content or "").strip()
+    except Exception as e:
+        print(f"[link_health] summarize_page_content error: {e}")
+        return ""
+
+
 def fetch_with_retries(
     url: str,
     max_retries: int = 3,

--- a/backend/tests/test_knowledge_links_service.py
+++ b/backend/tests/test_knowledge_links_service.py
@@ -330,16 +330,41 @@ class TestExploreLink:
         assert result.relevance_reason == "irrelevant"
 
     def test_falls_back_to_stored_description_for_judge_when_fetch_empty(self):
-        """When the page returns nothing useful, judge still runs using the stored description."""
+        """When the page returns nothing useful (including Jina), judge runs using stored description."""
         oid = ObjectId()
         col, doc = self._make_col(oid)
         mock_relevant = MagicMock(return_value=(True, None))
         with patch("app.services.link_health.fetch_page_metadata", return_value=("", "", "", 403)), \
+             patch("app.services.link_health.fetch_readable_content", return_value=""), \
              patch("app.services.link_health.is_relevant", mock_relevant):
             explore_link(col, str(oid), MagicMock(), set())
-        _, kwargs = mock_relevant.call_args
         link_arg = mock_relevant.call_args[0][1]
         assert link_arg["description"] == doc["description"]
+
+    def test_uses_ai_summary_when_meta_description_missing(self):
+        """When meta description is absent, Jina content is fetched and the LLM
+        generates a proper summary to use as the proposed description."""
+        oid = ObjectId()
+        col, _ = self._make_col(oid)
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("D&C Title", "", "", 200)), \
+             patch("app.services.link_health.fetch_readable_content", return_value="Divide and conquer splits a problem..."), \
+             patch("app.services.link_health.summarize_page_content", return_value="Covers divide and conquer algorithm design."), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            result = explore_link(col, str(oid), MagicMock(), set())
+        assert result.proposed_description == "Covers divide and conquer algorithm design."
+
+    def test_sets_article_excerpt_from_readable_content_when_body_empty(self):
+        """When article body extraction finds nothing but Jina returns content,
+        the first 500 chars of the readable content are used as the excerpt."""
+        oid = ObjectId()
+        col, _ = self._make_col(oid)
+        jina_text = "Readable content from Jina " * 5
+        with patch("app.services.link_health.fetch_page_metadata", return_value=("Title", "", "", 200)), \
+             patch("app.services.link_health.fetch_readable_content", return_value=jina_text), \
+             patch("app.services.link_health.summarize_page_content", return_value="Summary."), \
+             patch("app.services.link_health.is_relevant", return_value=(True, None)):
+            result = explore_link(col, str(oid), MagicMock(), set())
+        assert result.article_excerpt == jina_text[:500]
 
 
 # ── apply_explore (saves confirmed content) ───────────────────────────────────

--- a/backend/tests/test_link_health_service.py
+++ b/backend/tests/test_link_health_service.py
@@ -9,6 +9,8 @@ import pytest
 from app.services.link_health import (
     fetch_with_retries,
     fetch_page_metadata,
+    fetch_readable_content,
+    summarize_page_content,
     _first_article_paragraph,
     _is_generic_description,
     _url_slug_description,
@@ -306,6 +308,70 @@ class TestUrlSlugDescription:
 
     def test_empty_for_unknown_generic_only(self):
         assert _url_slug_description("https://example.com/index") == ""
+
+
+# ── fetch_readable_content ────────────────────────────────────────────────────
+
+class TestFetchReadableContent:
+    def _jina_ctx(self, text: str, status: int = 200):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.text = text
+        return _mock_httpx_client(resp)
+
+    def test_returns_text_on_200(self):
+        with patch("app.services.link_health.httpx.Client", return_value=self._jina_ctx("Article content here")):
+            result = fetch_readable_content("https://example.com/page", timeout=5)
+        assert result == "Article content here"
+
+    def test_truncates_to_4000_chars(self):
+        long_text = "A" * 5000
+        with patch("app.services.link_health.httpx.Client", return_value=self._jina_ctx(long_text)):
+            result = fetch_readable_content("https://example.com/page", timeout=5)
+        assert len(result) == 4000
+
+    def test_returns_empty_on_non_200(self):
+        with patch("app.services.link_health.httpx.Client", return_value=self._jina_ctx("", status=429)):
+            result = fetch_readable_content("https://example.com/page", timeout=5)
+        assert result == ""
+
+    def test_returns_empty_on_exception(self):
+        mock_client = MagicMock()
+        mock_client.get.side_effect = Exception("network error")
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=mock_client)
+        ctx.__exit__ = MagicMock(return_value=False)
+        with patch("app.services.link_health.httpx.Client", return_value=ctx):
+            result = fetch_readable_content("https://example.com/page", timeout=5)
+        assert result == ""
+
+
+# ── summarize_page_content ────────────────────────────────────────────────────
+
+class TestSummarizePageContent:
+    def _make_client(self, content: str):
+        client = MagicMock()
+        choice = MagicMock()
+        choice.message.content = content
+        client.chat.completions.create.return_value = MagicMock(choices=[choice])
+        return client
+
+    def test_returns_llm_summary(self):
+        client = self._make_client("Explains divide and conquer with examples.")
+        result = summarize_page_content("Some article text...", "Divide and Conquer", client)
+        assert result == "Explains divide and conquer with examples."
+
+    def test_returns_empty_for_empty_content(self):
+        client = self._make_client("Should not be called")
+        result = summarize_page_content("", "Title", client)
+        assert result == ""
+        client.chat.completions.create.assert_not_called()
+
+    def test_returns_empty_on_llm_failure(self):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = Exception("API error")
+        result = summarize_page_content("Some content", "Title", client)
+        assert result == ""
 
 
 # ── _first_article_paragraph ──────────────────────────────────────────────────


### PR DESCRIPTION
When the meta description is missing or generic, fetch the fully rendered page via r.jina.ai (handles SPA/JS-heavy sites like GeeksforGeeks where raw HTML has no article text) and ask the LLM to write a proper 1-2 sentence description instead of falling back to the bare URL slug. The raw Jina text surfaces as the article excerpt so the admin can verify the summary before saving. 98 tests passing.