### PR TITLE
feat: expand participant data collection

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -10,6 +10,7 @@ from ..schemas.auth import (
     AuthResponse,
     ChangePasswordRequest,
     ConsentAgreementRequest,
+    ConsentDeclineRequest,
 )
 from ..schemas.user import UserPublic, SurveyStage, AssignedVar
 from ..services.users import (
@@ -18,6 +19,7 @@ from ..services.users import (
     create_user,
     find_user_by_email,
     check_user_password,
+    maybe_touch_last_active,
 )
 from ..core.security import create_access_token, decode_token
 from ..core.config import get_settings
@@ -65,6 +67,8 @@ def build_user_public(doc: dict) -> UserPublic:
         consent_given_at=doc.get("consent_given_at"),
         consent_text=doc.get("consent_text"),
         consent_agreed_at=doc.get("consent_agreed_at"),
+        consent_declined_at=doc.get("consent_declined_at"),
+        last_active_at=doc.get("last_active_at"),
         assigned_var=doc.get("assigned_var", AssignedVar.followup.value),
         is_admin=bool(doc.get("is_admin", False)),
         demographics_completed=doc.get("demographics_completed", False),
@@ -96,6 +100,8 @@ def get_current_user(request: Request) -> UserPublic:
     doc = find_user_by_email(users, email)
     if not doc:
         raise HTTPException(status_code=401, detail="User not found")
+
+    maybe_touch_last_active(users, doc)
 
     return build_user_public(doc)
 
@@ -170,6 +176,32 @@ def record_consent_agreement(
             "$set": {
                 "consent_text": data.consent_text,
                 "consent_agreed_at": now,
+                "updated_at": now,
+            }
+        },
+    )
+
+    return {"ok": True}
+
+
+@router.post("/decline")
+def record_consent_decline(
+    data: ConsentDeclineRequest,
+    request: Request,
+    user: UserPublic = Depends(get_current_user),
+):
+    users = get_users_collection(request.app.state.db)
+    doc = find_user_by_email(users, user.email)
+    if not doc:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    now = datetime.now(timezone.utc)
+    users.update_one(
+        {"_id": doc["_id"]},
+        {
+            "$set": {
+                "consent_text": data.consent_text,
+                "consent_declined_at": now,
                 "updated_at": now,
             }
         },

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -11,13 +11,18 @@ from fastapi.responses import StreamingResponse
 
 from ..schemas.user import UserPublic
 from ..schemas.message import AIMessageMetadata
+from ..schemas.question import QuestionChoice
 from ..schemas.chat import (
     ChatRequest, ChatResponse, FollowupChatResponse, FollowupResponse,
     UserMessageData, UserConversationHistoryResponse,
     ConversationMessageData, ConversationHistoryResponse,
 )
 from .auth import get_current_user
-from ..services.chat import get_last_exchange, get_conversation_history as fetch_conversation_history
+from ..services.chat import (
+    get_last_exchange,
+    get_conversation_history as fetch_conversation_history,
+    detect_stated_choice,
+)
 from ..services.search import _build_search_context, _inject_citation_links
 # from ..services.search import _run_search, _filter_valid_urls  # external search disabled
 from ..services.followup import generate_followup_questions
@@ -90,6 +95,7 @@ def _save_message(
     conv_id: str,
     content,
     metadata=None,
+    extra_fields: dict | None = None,
 ) -> None:
     """Insert one message document. Raises on failure — callers must handle/log."""
     doc = {
@@ -103,10 +109,21 @@ def _save_message(
     }
     if metadata is not None:
         doc["metadata"] = metadata
+    if extra_fields:
+        doc.update(extra_fields)
     col.insert_one(doc)
 
 
-async def _save_exchange(col, user: UserPublic, conv_id: str, user_message: str, assistant_reply: list, assistant_metadata: dict | None = None) -> None:
+async def _save_exchange(
+    col,
+    user: UserPublic,
+    conv_id: str,
+    user_message: str,
+    assistant_reply: list,
+    assistant_metadata: dict | None = None,
+    question_id: Optional[str] = None,
+    trigger: Optional[str] = None,
+) -> None:
     """Persist the user message then the assistant reply, awaited before the
     caller reports success to the client.
 
@@ -116,14 +133,25 @@ async def _save_exchange(col, user: UserPublic, conv_id: str, user_message: str,
     loudly (with conversation/user context) rather than silently dropped — the
     participant already saw the reply stream in, so we don't fail the request
     over a persistence error, but it must never vanish without a trace.
+
+    question_id/trigger are stored as top-level fields (not nested in metadata)
+    since they identify the message itself, analogous to conversation_id.
+    trigger only applies to the user message — an assistant reply has no "trigger".
     """
     def _save() -> None:
+        user_extra = {}
+        if question_id is not None:
+            user_extra["question_id"] = question_id
+        if trigger is not None:
+            user_extra["trigger"] = trigger
         try:
-            _save_message(col, "user", user, conv_id, user_message)
+            _save_message(col, "user", user, conv_id, user_message, extra_fields=user_extra or None)
         except Exception as e:
             print(f"[chat] FAILED to save USER message conv={conv_id} user={user.id}: {type(e).__name__}: {e}")
+
+        assistant_extra = {"question_id": question_id} if question_id is not None else None
         try:
-            _save_message(col, "assistant", user, conv_id, assistant_reply, assistant_metadata)
+            _save_message(col, "assistant", user, conv_id, assistant_reply, assistant_metadata, extra_fields=assistant_extra)
         except Exception as e:
             print(f"[chat] FAILED to save ASSISTANT message conv={conv_id} user={user.id}: {type(e).__name__}: {e}")
 
@@ -241,11 +269,16 @@ async def _standard_stream(
     reply_prefix: str = "",
     answer_incorrectly: bool = False,
     temperature: float = TEMPERATURE,
+    question_id: Optional[str] = None,
+    trigger: Optional[str] = None,
+    answer_choices: Optional[list[QuestionChoice]] = None,
 ) -> AsyncGenerator[str, None]:
-    """Stream tokens, fire-and-forget saves, emit done, then optionally yield from after_done.
+    """Stream tokens, await the save, emit done, then optionally yield from after_done.
 
     agent_tag: if set, each token SSE includes an "agent" field (used by double quiz).
     reply_prefix: prepended to the stored reply (e.g. "[AGENT A] " for double quiz).
+    answer_choices: if provided, the leading text of the reply is scanned to detect
+    which choice the AI named, recorded in metadata.stated_choice_id["default"].
     """
     full_reply = ""
     async for is_error, delta, sse in _stream_agent_tokens(messages, agent_tag=agent_tag, temperature=temperature):
@@ -255,8 +288,10 @@ async def _standard_stream(
         full_reply += delta
 
     stored_reply = f"{reply_prefix}{full_reply}" if reply_prefix else full_reply
-    metadata = AIMessageMetadata(answer_incorrectly=answer_incorrectly).model_dump(exclude_none=True)
-    await _save_exchange(col, user, conv_id, user_message, [stored_reply], metadata)
+    choices = answer_choices or []
+    stated = {"default": detect_stated_choice(full_reply, choices)} if choices else None
+    metadata = AIMessageMetadata(answer_incorrectly=answer_incorrectly, stated_choice_id=stated).model_dump(exclude_none=True)
+    await _save_exchange(col, user, conv_id, user_message, [stored_reply], metadata, question_id=question_id, trigger=trigger)
     yield _sse({"type": "done", "conversation_id": conv_id})
 
     if after_done and not (request and await request.is_disconnected()):
@@ -339,7 +374,9 @@ async def double_chat(
             _standard_stream(msgs, col, user, conv_id, req.message,
                              agent_tag=tag, reply_prefix=f"[AGENT {tag}] ",
                              answer_incorrectly=req.answer_incorrectly,
-                             temperature=DOUBLE_TEMPERATURE),
+                             temperature=DOUBLE_TEMPERATURE,
+                             question_id=req.question_id, trigger=req.trigger,
+                             answer_choices=req.answer_choices),
             media_type="text/event-stream",
             headers=_SSE_HEADERS,
         )
@@ -370,8 +407,16 @@ async def double_chat(
             replies[tag] += delta
 
         replies_to_store = [f"[AGENT A] {replies['A']}", f"[AGENT B] {replies['B']}"]
-        metadata = AIMessageMetadata(answer_incorrectly=req.answer_incorrectly).model_dump(exclude_none=True)
-        await _save_exchange(col, user, conv_id, req.message, replies_to_store, assistant_metadata=metadata)
+        stated = (
+            {
+                "A": detect_stated_choice(replies["A"], req.answer_choices),
+                "B": detect_stated_choice(replies["B"], req.answer_choices),
+            }
+            if req.answer_choices else None
+        )
+        metadata = AIMessageMetadata(answer_incorrectly=req.answer_incorrectly, stated_choice_id=stated).model_dump(exclude_none=True)
+        await _save_exchange(col, user, conv_id, req.message, replies_to_store, assistant_metadata=metadata,
+                              question_id=req.question_id, trigger=req.trigger)
         yield _sse({"type": "done", "conversation_id": conv_id})
 
     return StreamingResponse(generate(), media_type="text/event-stream", headers=_SSE_HEADERS)
@@ -400,7 +445,9 @@ async def followup_quiz_chat(
             yield _sse({"type": "followup", "token": delta})
 
     return StreamingResponse(
-        _standard_stream(messages, col, user, conv_id, req.message, after_done=after_done, request=request, answer_incorrectly=req.answer_incorrectly),
+        _standard_stream(messages, col, user, conv_id, req.message, after_done=after_done, request=request,
+                         answer_incorrectly=req.answer_incorrectly,
+                         question_id=req.question_id, trigger=req.trigger, answer_choices=req.answer_choices),
         media_type="text/event-stream",
         headers=_SSE_HEADERS,
     )
@@ -467,8 +514,10 @@ async def chat_with_embedded_links(
         # valid_citations = [c for c in citations if c["url"] in valid_urls]  # disabled with search
 
         stored_reply = _inject_citation_links(full_reply, citations) if citations else full_reply
-        metadata = AIMessageMetadata(answer_incorrectly=req.answer_incorrectly).model_dump(exclude_none=True)
-        await _save_exchange(request.app.state.messages, user, conv_id, req.message, [stored_reply], assistant_metadata=metadata)
+        stated = {"default": detect_stated_choice(full_reply, req.answer_choices)} if req.answer_choices else None
+        metadata = AIMessageMetadata(answer_incorrectly=req.answer_incorrectly, stated_choice_id=stated).model_dump(exclude_none=True)
+        await _save_exchange(request.app.state.messages, user, conv_id, req.message, [stored_reply], assistant_metadata=metadata,
+                              question_id=req.question_id, trigger=req.trigger)
 
         yield _sse({"type": "done", "conversation_id": conv_id, "reply": stored_reply})
 
@@ -496,7 +545,8 @@ async def chat(
     messages = _build_standard_messages(history, req.message, system_prompt=system_instruction)
 
     return StreamingResponse(
-        _standard_stream(messages, col, user, conv_id, req.message, answer_incorrectly=req.answer_incorrectly),
+        _standard_stream(messages, col, user, conv_id, req.message, answer_incorrectly=req.answer_incorrectly,
+                         question_id=req.question_id, trigger=req.trigger, answer_choices=req.answer_choices),
         media_type="text/event-stream",
         headers=_SSE_HEADERS,
     )

--- a/backend/app/api/copy_events.py
+++ b/backend/app/api/copy_events.py
@@ -1,0 +1,36 @@
+# backend/app/api/copy_events.py
+from typing import List
+from fastapi import APIRouter, Request, Depends
+
+from ..schemas.copy_event import CopyEventCreate, CopyEventPublic
+from ..schemas.user import UserPublic
+from ..api.auth import get_current_user
+from ..services.copy_events import (
+    get_copy_events_collection,
+    ensure_indexes,
+    create_copy_event,
+    list_copy_events,
+)
+
+router = APIRouter(prefix="/copy-events", tags=["copy-events"])
+
+
+@router.post("", response_model=CopyEventPublic)
+def record_copy_event(
+    data: CopyEventCreate,
+    request: Request,
+    user: UserPublic = Depends(get_current_user),
+):
+    col = get_copy_events_collection(request.app.state.db)
+    ensure_indexes(col)
+    return create_copy_event(col, user, data)
+
+
+@router.get("", response_model=List[CopyEventPublic])
+def get_copy_events(
+    request: Request,
+    user: UserPublic = Depends(get_current_user),
+):
+    col = get_copy_events_collection(request.app.state.db)
+    user_id = None if user.is_admin else user.id
+    return list_copy_events(col, user_id=user_id)

--- a/backend/app/api/link_clicks.py
+++ b/backend/app/api/link_clicks.py
@@ -1,0 +1,36 @@
+# backend/app/api/link_clicks.py
+from typing import List, Optional
+from fastapi import APIRouter, Request, Depends
+
+from ..schemas.link_click import LinkClickCreate, LinkClickPublic
+from ..schemas.user import UserPublic
+from ..api.auth import get_current_user
+from ..services.link_clicks import (
+    get_link_clicks_collection,
+    ensure_indexes,
+    create_link_click,
+    list_link_clicks,
+)
+
+router = APIRouter(prefix="/links", tags=["links"])
+
+
+@router.post("/clicks", response_model=LinkClickPublic)
+def record_link_click(
+    data: LinkClickCreate,
+    request: Request,
+    user: UserPublic = Depends(get_current_user),
+):
+    col = get_link_clicks_collection(request.app.state.db)
+    ensure_indexes(col)
+    return create_link_click(col, user, data)
+
+
+@router.get("/clicks", response_model=List[LinkClickPublic])
+def get_link_clicks(
+    request: Request,
+    user: UserPublic = Depends(get_current_user),
+):
+    col = get_link_clicks_collection(request.app.state.db)
+    user_id = None if user.is_admin else user.id
+    return list_link_clicks(col, user_id=user_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,8 @@ from .api.auth import router as auth_router
 from .api.knowledge_links import router as knowledge_links_router
 from .api.allowlist import router as allowlist_router
 from .api.reports import router as reports_router
+from .api.link_clicks import router as link_clicks_router
+from .api.copy_events import router as copy_events_router
 from .api import questions as questions_router
 from .api import quiz as quiz_router
 from .api import demographics as demographics_router
@@ -99,6 +101,12 @@ def _startup():
         from .services.reports import get_reports_collection, ensure_indexes as ensure_reports_indexes
         ensure_reports_indexes(get_reports_collection(db))
 
+        from .services.link_clicks import get_link_clicks_collection, ensure_indexes as ensure_link_clicks_indexes
+        ensure_link_clicks_indexes(get_link_clicks_collection(db))
+
+        from .services.copy_events import get_copy_events_collection, ensure_indexes as ensure_copy_events_indexes
+        ensure_copy_events_indexes(get_copy_events_collection(db))
+
         # Start background scheduler (last, after all caches are ready)
         from .scheduler import start_scheduler
         start_scheduler(app)
@@ -137,3 +145,5 @@ app.include_router(quiz_router.router)
 app.include_router(demographics_router.router)
 app.include_router(surveys_router.router)
 app.include_router(reports_router)
+app.include_router(link_clicks_router)
+app.include_router(copy_events_router)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -35,3 +35,10 @@ class ChangePasswordRequest(BaseModel):
 # consent form is edited later.
 class ConsentAgreementRequest(BaseModel):
     consent_text: str = Field(min_length=1)
+
+
+# Payload sent by the client when the user clicks "I do not wish to participate"
+# on the consent page. Mirrors ConsentAgreementRequest so the team can see
+# exactly what text was shown when someone declined, not just that they did.
+class ConsentDeclineRequest(BaseModel):
+    consent_text: str = Field(min_length=1)

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -13,6 +13,8 @@ class ChatRequest(BaseModel):
     answer_incorrectly: bool = False
     question_text: str | None = None
     answer_choices: list[QuestionChoice] = Field(default_factory=list)
+    question_id: str | None = None
+    trigger: str | None = None  # "manual" | "followup_chip" | "auto_question"
 
 
 # Returned by non-streaming chat endpoints (e.g. legacy or search-based).

--- a/backend/app/schemas/copy_event.py
+++ b/backend/app/schemas/copy_event.py
@@ -1,0 +1,22 @@
+# backend/app/schemas/copy_event.py
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class CopyEventCreate(BaseModel):
+    quiz_id: Optional[str] = None
+    question_id: Optional[str] = None
+    conversation_id: Optional[str] = None
+    copied_text: str = Field(min_length=1, max_length=2000)
+
+
+class CopyEventPublic(BaseModel):
+    id: str
+    user_id: str
+    user_email: str
+    quiz_id: Optional[str] = None
+    question_id: Optional[str] = None
+    conversation_id: Optional[str] = None
+    copied_text: str
+    created_at: datetime

--- a/backend/app/schemas/link_click.py
+++ b/backend/app/schemas/link_click.py
@@ -1,0 +1,22 @@
+# backend/app/schemas/link_click.py
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+
+
+class LinkClickCreate(BaseModel):
+    quiz_id: Optional[str] = None
+    question_id: Optional[str] = None
+    conversation_id: Optional[str] = None
+    url: str = Field(min_length=1)
+
+
+class LinkClickPublic(BaseModel):
+    id: str
+    user_id: str
+    user_email: str
+    quiz_id: Optional[str] = None
+    question_id: Optional[str] = None
+    conversation_id: Optional[str] = None
+    url: str
+    clicked_at: datetime

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -53,6 +53,14 @@ class AIMessageMetadata(BaseModel):
         default=None,
         description="Whether the AI was instructed to answer incorrectly"
     )
+    stated_choice_id: Optional[dict[str, Optional[str]]] = Field(
+        default=None,
+        description=(
+            "Maps an agent tag to the answer-choice id the reply named. "
+            "Single-agent endpoints use the key 'default'; dual-agent mode uses "
+            "'A'/'B'. A None value means no single choice could be confidently detected."
+        )
+    )
     custom_metadata: Optional[dict[str, Any]] = Field(
         default=None,
         description="Flexible field for any additional metadata or analysis data"

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -56,6 +56,8 @@ class UserPublic(BaseModel):
     consent_given_at: Optional[datetime] = None
     consent_text: Optional[str] = None
     consent_agreed_at: Optional[datetime] = None
+    consent_declined_at: Optional[datetime] = None
+    last_active_at: Optional[datetime] = None
     assigned_var: AssignedVar = AssignedVar.followup
     is_admin: bool = False
     demographics_completed: bool = False

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -3,6 +3,21 @@ import re
 from typing import Optional
 from pymongo.collection import Collection
 
+from ..schemas.question import QuestionChoice
+
+
+def detect_stated_choice(reply_text: str, choices: list[QuestionChoice]) -> Optional[str]:
+    """Heuristic: case-insensitive substring match of each choice's label against
+    the leading 300 chars of reply_text (the system prompt forces the AI to name
+    its choice up front). Returns the id only on exactly one confident match;
+    returns None on zero or ambiguous (2+) matches — never guesses.
+    """
+    if not choices:
+        return None
+    window = reply_text[:300].lower()
+    matches = [c.id for c in choices if c.label.strip().lower() in window]
+    return matches[0] if len(matches) == 1 else None
+
 
 def _format_assistant(content) -> str:
     """Combine agent replies into a single assistant message string.

--- a/backend/app/services/copy_events.py
+++ b/backend/app/services/copy_events.py
@@ -1,0 +1,53 @@
+# backend/app/services/copy_events.py
+from typing import Optional, List
+from datetime import datetime, timezone
+from pymongo.collection import Collection
+
+from ..schemas.copy_event import CopyEventCreate, CopyEventPublic
+
+
+def get_copy_events_collection(db) -> Collection:
+    return db["copy_events"]
+
+
+def ensure_indexes(col: Collection) -> None:
+    col.create_index("user_id")
+    col.create_index("conversation_id")
+    col.create_index([("created_at", -1)])
+
+
+def _to_public(doc: dict) -> CopyEventPublic:
+    return CopyEventPublic(
+        id=str(doc["_id"]),
+        user_id=doc["user_id"],
+        user_email=doc["user_email"],
+        quiz_id=doc.get("quiz_id"),
+        question_id=doc.get("question_id"),
+        conversation_id=doc.get("conversation_id"),
+        copied_text=doc["copied_text"],
+        created_at=doc["created_at"],
+    )
+
+
+def create_copy_event(col: Collection, user, data: CopyEventCreate) -> CopyEventPublic:
+    now = datetime.now(timezone.utc)
+    doc = {
+        "user_id": user.id,
+        "user_email": user.email,
+        "quiz_id": data.quiz_id,
+        "question_id": data.question_id,
+        "conversation_id": data.conversation_id,
+        "copied_text": data.copied_text,
+        "created_at": now,
+    }
+    res = col.insert_one(doc)
+    doc["_id"] = res.inserted_id
+    return _to_public(doc)
+
+
+def list_copy_events(col: Collection, user_id: Optional[str] = None) -> List[CopyEventPublic]:
+    query: dict = {}
+    if user_id is not None:
+        query["user_id"] = user_id
+    docs = col.find(query).sort("created_at", -1)
+    return [_to_public(doc) for doc in docs]

--- a/backend/app/services/link_clicks.py
+++ b/backend/app/services/link_clicks.py
@@ -1,0 +1,53 @@
+# backend/app/services/link_clicks.py
+from typing import Optional, List
+from datetime import datetime, timezone
+from pymongo.collection import Collection
+
+from ..schemas.link_click import LinkClickCreate, LinkClickPublic
+
+
+def get_link_clicks_collection(db) -> Collection:
+    return db["link_clicks"]
+
+
+def ensure_indexes(col: Collection) -> None:
+    col.create_index("user_id")
+    col.create_index("conversation_id")
+    col.create_index([("clicked_at", -1)])
+
+
+def _to_public(doc: dict) -> LinkClickPublic:
+    return LinkClickPublic(
+        id=str(doc["_id"]),
+        user_id=doc["user_id"],
+        user_email=doc["user_email"],
+        quiz_id=doc.get("quiz_id"),
+        question_id=doc.get("question_id"),
+        conversation_id=doc.get("conversation_id"),
+        url=doc["url"],
+        clicked_at=doc["clicked_at"],
+    )
+
+
+def create_link_click(col: Collection, user, data: LinkClickCreate) -> LinkClickPublic:
+    now = datetime.now(timezone.utc)
+    doc = {
+        "user_id": user.id,
+        "user_email": user.email,
+        "quiz_id": data.quiz_id,
+        "question_id": data.question_id,
+        "conversation_id": data.conversation_id,
+        "url": data.url,
+        "clicked_at": now,
+    }
+    res = col.insert_one(doc)
+    doc["_id"] = res.inserted_id
+    return _to_public(doc)
+
+
+def list_link_clicks(col: Collection, user_id: Optional[str] = None) -> List[LinkClickPublic]:
+    query: dict = {}
+    if user_id is not None:
+        query["user_id"] = user_id
+    docs = col.find(query).sort("clicked_at", -1)
+    return [_to_public(doc) for doc in docs]

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -1,11 +1,13 @@
 # backend/app/services/users.py
 from typing import Optional
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pymongo.collection import Collection
 from pymongo import ReturnDocument
 
 from ..schemas.user import UserPublic, SurveyStage, AssignedVar
 from ..core.security import hash_password, verify_password
+
+_HEARTBEAT_DEBOUNCE = timedelta(minutes=2)
 
 
 def _normalize_stage(raw) -> SurveyStage:
@@ -35,6 +37,8 @@ def _to_public(doc: dict) -> UserPublic:
         consent_given_at=doc.get("consent_given_at"),
         consent_text=doc.get("consent_text"),
         consent_agreed_at=doc.get("consent_agreed_at"),
+        consent_declined_at=doc.get("consent_declined_at"),
+        last_active_at=doc.get("last_active_at"),
         assigned_var=doc.get("assigned_var", AssignedVar.followup.value),
         is_admin=bool(doc.get("is_admin", False)),
         demographics_completed=doc.get("demographics_completed", False),
@@ -113,6 +117,25 @@ def create_user(
     doc["assigned_var"] = assigned_var
 
     return _to_public(doc)
+
+
+def maybe_touch_last_active(users: Collection, user_doc: dict) -> None:
+    """Update last_active_at only if more than _HEARTBEAT_DEBOUNCE has passed
+    since the last recorded value, to avoid a write on every single
+    authenticated request (get_current_user runs on every one).
+    """
+    now = datetime.now(timezone.utc)
+    last = user_doc.get("last_active_at")
+    if last is not None:
+        # pymongo returns stored datetimes as naive UTC by default (no tz_aware
+        # codec option on this client) — attach tzinfo before subtracting, or a
+        # round-tripped value would raise "can't subtract offset-naive and
+        # offset-aware datetimes" on every second heartbeat check.
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
+        if (now - last) < _HEARTBEAT_DEBOUNCE:
+            return
+    users.update_one({"_id": user_doc["_id"]}, {"$set": {"last_active_at": now}})
 
 
 def find_user_by_email(users: Collection, email: str) -> Optional[dict]:

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -252,6 +252,23 @@ class TestMe:
         assert resp.status_code == 200
         assert resp.json()["user"]["email"] == "student@test.edu"
 
+    def test_touches_last_active_at_on_request(self, auth_client, auth_mock_col):
+        """get_current_user runs on every authenticated request and should
+        record a heartbeat (subject to the debounce — see test_users_service.py
+        for the debounce logic itself)."""
+        settings = get_settings()
+        doc = make_user_doc(email="student@test.edu")  # no last_active_at set
+        token = create_access_token("student@test.edu")
+        auth_client.cookies.set(settings.COOKIE_NAME, token)
+        auth_mock_col.find_one.return_value = doc
+
+        auth_client.get("/auth/me")
+
+        auth_mock_col.update_one.assert_called_once()
+        args = auth_mock_col.update_one.call_args[0]
+        assert args[0] == {"_id": doc["_id"]}
+        assert "last_active_at" in args[1]["$set"]
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # POST /auth/logout
@@ -333,6 +350,66 @@ class TestRecordConsentAgreement:
         assert resp.status_code == 200
         assert resp.json()["user"]["consent_text"] == "Research Consent Form ... I agree to participate"
         assert resp.json()["user"]["consent_agreed_at"] is not None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# POST /auth/decline
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRecordConsentDecline:
+    def test_saves_consent_text_and_timestamp(self, overridden_client, auth_mock_col, regular_user):
+        doc = make_user_doc(email=regular_user.email)
+        auth_mock_col.find_one.return_value = doc
+
+        resp = overridden_client.post("/auth/decline", json={
+            "consent_text": "Research Consent Form ... I do not wish to participate",
+        })
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        args, kwargs = auth_mock_col.update_one.call_args
+        assert args[0] == {"_id": doc["_id"]}
+        set_doc = args[1]["$set"]
+        assert set_doc["consent_text"] == "Research Consent Form ... I do not wish to participate"
+        assert "consent_declined_at" in set_doc
+        assert "updated_at" in set_doc
+
+    def test_empty_consent_text_returns_422(self, overridden_client):
+        resp = overridden_client.post("/auth/decline", json={"consent_text": ""})
+        assert resp.status_code == 422
+
+    def test_missing_field_returns_422(self, overridden_client):
+        resp = overridden_client.post("/auth/decline", json={})
+        assert resp.status_code == 422
+
+    def test_user_not_found_returns_404(self, overridden_client, auth_mock_col):
+        auth_mock_col.find_one.return_value = None
+
+        resp = overridden_client.post("/auth/decline", json={"consent_text": "Some text"})
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "User not found"
+
+    def test_requires_authentication(self, auth_client):
+        resp = auth_client.post("/auth/decline", json={"consent_text": "Some text"})
+        assert resp.status_code == 401
+
+    def test_me_returns_saved_decline_timestamp(self, auth_client, auth_mock_col):
+        settings = get_settings()
+        doc = make_user_doc(
+            email="student@test.edu",
+            consent_text="Research Consent Form ... I do not wish to participate",
+            consent_declined_at=datetime.now(timezone.utc),
+        )
+        token = create_access_token("student@test.edu")
+        auth_client.cookies.set(settings.COOKIE_NAME, token)
+        auth_mock_col.find_one.return_value = doc
+
+        resp = auth_client.get("/auth/me")
+
+        assert resp.status_code == 200
+        assert resp.json()["user"]["consent_declined_at"] is not None
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -19,6 +19,7 @@ from fastapi.testclient import TestClient
 from app.api import chat as chat_module
 from app.api.auth import get_current_user
 from app.schemas.user import UserPublic
+from app.schemas.question import QuestionChoice
 
 
 # ── Fake OpenAI streaming helpers ────────────────────────────────────────────
@@ -250,6 +251,30 @@ class TestSaveMessage:
         with pytest.raises(RuntimeError):
             chat_module._save_message(col, "user", user, "conv1", "hello")
 
+    def test_extra_fields_merged_into_doc(self):
+        col = MagicMock()
+        user = UserPublic(id="u1", email="a@b.com", is_admin=False)
+
+        chat_module._save_message(
+            col, "user", user, "conv1", "hello",
+            extra_fields={"question_id": "q1", "trigger": "followup_chip"},
+        )
+
+        doc = col.insert_one.call_args.args[0]
+        assert doc["question_id"] == "q1"
+        assert doc["trigger"] == "followup_chip"
+        bson.encode(doc)
+
+    def test_no_extra_fields_omits_them(self):
+        col = MagicMock()
+        user = UserPublic(id="u1", email="a@b.com", is_admin=False)
+
+        chat_module._save_message(col, "user", user, "conv1", "hello")
+
+        doc = col.insert_one.call_args.args[0]
+        assert "question_id" not in doc
+        assert "trigger" not in doc
+
 
 # ── _save_exchange ────────────────────────────────────────────────────────────
 
@@ -302,6 +327,36 @@ class TestSaveExchange:
 
         # Both inserts were attempted even though the first one failed.
         assert col.insert_one.call_count == 2
+
+    def test_question_id_stored_on_both_docs_trigger_only_on_user_doc(self):
+        col = MagicMock()
+        user = UserPublic(id="u1", email="a@b.com", is_admin=False)
+
+        asyncio.run(
+            chat_module._save_exchange(
+                col, user, "conv1", "hello", ["hi there"], None,
+                question_id="q1", trigger="followup_chip",
+            )
+        )
+
+        user_doc, assistant_doc = (c.args[0] for c in col.insert_one.call_args_list)
+        assert user_doc["question_id"] == "q1"
+        assert user_doc["trigger"] == "followup_chip"
+        assert assistant_doc["question_id"] == "q1"
+        assert "trigger" not in assistant_doc
+
+    def test_no_question_id_or_trigger_omits_both_fields(self):
+        col = MagicMock()
+        user = UserPublic(id="u1", email="a@b.com", is_admin=False)
+
+        asyncio.run(
+            chat_module._save_exchange(col, user, "conv1", "hello", ["hi there"], None)
+        )
+
+        user_doc, assistant_doc = (c.args[0] for c in col.insert_one.call_args_list)
+        assert "question_id" not in user_doc
+        assert "trigger" not in user_doc
+        assert "question_id" not in assistant_doc
 
 
 # ── _stream_ai ─────────────────────────────────────────────────────────────────
@@ -465,6 +520,56 @@ class TestStandardStream:
         assert events[-1] == chat_module._sse({"type": "done", "conversation_id": "conv1"})
         assert called is False
 
+    def test_question_id_and_trigger_passed_to_save(self, monkeypatch):
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _mock_create(["foo"]))
+        col = MagicMock()
+        user = UserPublic(id="u1", email="a@b.com", is_admin=False)
+
+        async def run():
+            async for _ in chat_module._standard_stream(
+                [{"role": "user", "content": "hi"}], col, user, "conv1", "hi",
+                question_id="q1", trigger="manual",
+            ):
+                pass
+
+        asyncio.run(run())
+        user_doc, assistant_doc = (c.args[0] for c in col.insert_one.call_args_list)
+        assert user_doc["question_id"] == "q1"
+        assert user_doc["trigger"] == "manual"
+        assert assistant_doc["question_id"] == "q1"
+
+    def test_stated_choice_detected_with_answer_choices(self, monkeypatch):
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _mock_create(["The answer is 4."]))
+        col = MagicMock()
+        user = UserPublic(id="u1", email="a@b.com", is_admin=False)
+        choices = [QuestionChoice(id="a", label="3"), QuestionChoice(id="b", label="4")]
+
+        async def run():
+            async for _ in chat_module._standard_stream(
+                [{"role": "user", "content": "hi"}], col, user, "conv1", "hi",
+                answer_choices=choices,
+            ):
+                pass
+
+        asyncio.run(run())
+        assistant_doc = col.insert_one.call_args_list[1].args[0]
+        assert assistant_doc["metadata"]["stated_choice_id"] == {"default": "b"}
+
+    def test_no_stated_choice_field_without_answer_choices(self, monkeypatch):
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _mock_create(["The answer is 4."]))
+        col = MagicMock()
+        user = UserPublic(id="u1", email="a@b.com", is_admin=False)
+
+        async def run():
+            async for _ in chat_module._standard_stream(
+                [{"role": "user", "content": "hi"}], col, user, "conv1", "hi",
+            ):
+                pass
+
+        asyncio.run(run())
+        assistant_doc = col.insert_one.call_args_list[1].args[0]
+        assert "stated_choice_id" not in assistant_doc.get("metadata", {})
+
 
 # ── _stream_into_queue ───────────────────────────────────────────────────────────
 
@@ -561,6 +666,32 @@ class TestDefaultChatEndpoint:
         sent_messages = create_mock.call_args.kwargs["messages"]
         assert "MUST choose an incorrect answer choice" in sent_messages[0]["content"]
 
+    def test_question_id_and_trigger_round_trip_to_stored_docs(self, monkeypatch, chat_client, chat_col):
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _mock_create(["hi"]))
+
+        resp = chat_client.post("/chat/quiz1", json={
+            "message": "hi", "conversation_id": "conv1",
+            "question_id": "q42", "trigger": "auto_question",
+        })
+
+        assert resp.status_code == 200
+        user_doc, assistant_doc = (c.args[0] for c in chat_col.insert_one.call_args_list)
+        assert user_doc["question_id"] == "q42"
+        assert user_doc["trigger"] == "auto_question"
+        assert assistant_doc["question_id"] == "q42"
+
+    def test_stated_choice_id_round_trips_to_stored_metadata(self, monkeypatch, chat_client, chat_col):
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _mock_create(["The answer is 4."]))
+
+        resp = chat_client.post("/chat/quiz1", json={
+            "message": "What is 2+2?",
+            "answer_choices": [{"id": "a", "label": "3"}, {"id": "b", "label": "4"}],
+        })
+
+        assert resp.status_code == 200
+        assistant_doc = chat_col.insert_one.call_args_list[1].args[0]
+        assert assistant_doc["metadata"]["stated_choice_id"] == {"default": "b"}
+
 
 # ── POST /chat/double ──────────────────────────────────────────────────────────
 
@@ -620,6 +751,49 @@ class TestDoubleChatEndpoint:
         assert assistant_doc["metadata"] == {"answer_incorrectly": False}
         bson.encode(assistant_doc)
 
+    def test_both_agents_stated_choice_detected_per_agent(self, monkeypatch, chat_client, chat_col):
+        monkeypatch.setattr(
+            chat_module._client.chat.completions, "create",
+            _agent_aware_create(["The answer is 3, intuitively."], ["The answer is 4, formally."]),
+        )
+
+        resp = chat_client.post("/chat/double", json={
+            "message": "hi", "conversation_id": "conv1", "agents": [],
+            "answer_choices": [{"id": "a", "label": "3"}, {"id": "b", "label": "4"}],
+        })
+
+        assert resp.status_code == 200
+        assistant_doc = chat_col.insert_one.call_args_list[1].args[0]
+        assert assistant_doc["metadata"]["stated_choice_id"] == {"A": "a", "B": "b"}
+
+    def test_question_id_and_trigger_round_trip_both_agents(self, monkeypatch, chat_client, chat_col):
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _agent_aware_create(["a"], ["b"]))
+
+        resp = chat_client.post("/chat/double", json={
+            "message": "hi", "conversation_id": "conv1", "agents": [],
+            "question_id": "q7", "trigger": "manual",
+        })
+
+        assert resp.status_code == 200
+        user_doc, assistant_doc = (c.args[0] for c in chat_col.insert_one.call_args_list)
+        assert user_doc["question_id"] == "q7"
+        assert user_doc["trigger"] == "manual"
+        assert assistant_doc["question_id"] == "q7"
+
+    def test_single_agent_via_mention_question_id_round_trips(self, monkeypatch, chat_client, chat_col):
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _agent_aware_create(["solo"], ["unused"]))
+
+        resp = chat_client.post("/chat/double", json={
+            "message": "hi", "conversation_id": "conv1", "agents": ["AgentA"],
+            "question_id": "q9", "trigger": "followup_chip",
+        })
+
+        assert resp.status_code == 200
+        user_doc, assistant_doc = (c.args[0] for c in chat_col.insert_one.call_args_list)
+        assert user_doc["question_id"] == "q9"
+        assert user_doc["trigger"] == "followup_chip"
+        assert assistant_doc["question_id"] == "q9"
+
 
 # ── POST /chat/followup ─────────────────────────────────────────────────────────
 
@@ -644,6 +818,23 @@ class TestFollowupChatEndpoint:
         assert events[1] == {"type": "done", "conversation_id": "conv2"}
         followups = [e for e in events if e["type"] == "followup"]
         assert followups == [{"type": "followup", "token": "1. Q1\n2. Q2\n3. Q3"}]
+
+    def test_question_id_and_trigger_round_trip(self, monkeypatch, chat_client, chat_col):
+        monkeypatch.setattr(
+            chat_module._client.chat.completions, "create",
+            _mock_create_sequence([["main answer"], ["1. Q1"]]),
+        )
+
+        resp = chat_client.post("/chat/followup", json={
+            "message": "explain", "conversation_id": "conv2",
+            "question_id": "q5", "trigger": "manual",
+        })
+
+        assert resp.status_code == 200
+        user_doc, assistant_doc = (c.args[0] for c in chat_col.insert_one.call_args_list)
+        assert user_doc["question_id"] == "q5"
+        assert user_doc["trigger"] == "manual"
+        assert assistant_doc["question_id"] == "q5"
 
 
 # ── POST /chat/links ──────────────────────────────────────────────────────────
@@ -705,6 +896,34 @@ class TestLinksChatEndpoint:
         events = _parse_sse(resp.text)
         assert events == [{"type": "error", "detail": "Upstream AI request failed"}]
         chat_col.insert_one.assert_not_called()
+
+    def test_question_id_and_trigger_round_trip(self, monkeypatch, chat_client, chat_app, chat_col):
+        chat_app.state.knowledge_links = []
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _mock_create(["plain answer"]))
+
+        resp = chat_client.post("/chat/links", json={
+            "message": "hi", "conversation_id": "conv3",
+            "question_id": "q11", "trigger": "manual",
+        })
+
+        assert resp.status_code == 200
+        user_doc, assistant_doc = (c.args[0] for c in chat_col.insert_one.call_args_list)
+        assert user_doc["question_id"] == "q11"
+        assert user_doc["trigger"] == "manual"
+        assert assistant_doc["question_id"] == "q11"
+
+    def test_stated_choice_id_detected(self, monkeypatch, chat_client, chat_app, chat_col):
+        chat_app.state.knowledge_links = []
+        monkeypatch.setattr(chat_module._client.chat.completions, "create", _mock_create(["The answer is 4."]))
+
+        resp = chat_client.post("/chat/links", json={
+            "message": "What is 2+2?", "conversation_id": "conv3",
+            "answer_choices": [{"id": "a", "label": "3"}, {"id": "b", "label": "4"}],
+        })
+
+        assert resp.status_code == 200
+        assistant_doc = chat_col.insert_one.call_args_list[1].args[0]
+        assert assistant_doc["metadata"]["stated_choice_id"] == {"default": "b"}
 
 
 # ── GET /chat/get_history/{conversation_id} ───────────────────────────────────

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, call
 from bson import ObjectId
 import pytest
 
-from app.services.chat import get_last_exchange
+from app.services.chat import get_last_exchange, detect_stated_choice
+from app.schemas.question import QuestionChoice
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -151,3 +152,41 @@ class TestGetLastExchange:
 
         find_call_kwargs = col.find.call_args[0][0]
         assert find_call_kwargs.get("conversation_id") == "my-conv-id-123"
+
+
+# ── detect_stated_choice ─────────────────────────────────────────────────────
+
+_CHOICES = [
+    QuestionChoice(id="a", label="3"),
+    QuestionChoice(id="b", label="4"),
+    QuestionChoice(id="c", label="5"),
+]
+
+
+class TestDetectStatedChoice:
+    def test_no_choices_returns_none(self):
+        assert detect_stated_choice("The answer is 4.", []) is None
+
+    def test_single_confident_match_returns_id(self):
+        reply = "The correct answer is 4, because 2+2=4."
+        assert detect_stated_choice(reply, _CHOICES) == "b"
+
+    def test_zero_matches_returns_none(self):
+        reply = "I'm not sure what the answer is."
+        assert detect_stated_choice(reply, _CHOICES) is None
+
+    def test_ambiguous_two_matches_returns_none(self):
+        # Both "4" and "5" appear in the leading text — never guess.
+        reply = "The answer is either 4 or 5 depending on rounding."
+        assert detect_stated_choice(reply, _CHOICES) is None
+
+    def test_match_outside_leading_window_is_not_detected(self):
+        # "4" only appears past the 300-char window the heuristic scans.
+        padding = "x" * 290
+        reply = f"{padding} the answer is 4"
+        assert detect_stated_choice(reply, _CHOICES) is None
+
+    def test_case_insensitive_match(self):
+        choices = [QuestionChoice(id="a", label="True"), QuestionChoice(id="b", label="False")]
+        reply = "TRUE — here's why."
+        assert detect_stated_choice(reply, choices) == "a"

--- a/backend/tests/test_copy_events_api.py
+++ b/backend/tests/test_copy_events_api.py
@@ -1,0 +1,116 @@
+# backend/tests/test_copy_events_api.py
+"""FastAPI TestClient integration tests for app.api.copy_events."""
+from unittest.mock import MagicMock
+
+import pytest
+from bson import ObjectId
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.copy_events import router as copy_events_router
+from app.api.auth import get_current_user
+
+
+# ── Local app/fixtures (do not touch conftest.py) ────────────────────────────
+
+@pytest.fixture
+def ce_mock_col():
+    return MagicMock()
+
+
+@pytest.fixture
+def ce_mock_db(ce_mock_col):
+    db = MagicMock()
+    db.__getitem__ = MagicMock(return_value=ce_mock_col)
+    return db
+
+
+@pytest.fixture
+def ce_app(ce_mock_db, regular_user):
+    app = FastAPI()
+    app.include_router(copy_events_router)
+    app.state.db = ce_mock_db
+    app.dependency_overrides[get_current_user] = lambda: regular_user
+    return app
+
+
+@pytest.fixture
+def ce_client(ce_app):
+    return TestClient(ce_app)
+
+
+@pytest.fixture
+def ce_admin_app(ce_mock_db, admin_user):
+    app = FastAPI()
+    app.include_router(copy_events_router)
+    app.state.db = ce_mock_db
+    app.dependency_overrides[get_current_user] = lambda: admin_user
+    return app
+
+
+@pytest.fixture
+def ce_admin_client(ce_admin_app):
+    return TestClient(ce_admin_app)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# POST /copy-events
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRecordCopyEvent:
+    def test_succeeds_for_regular_user_no_admin_required(self, ce_client, ce_mock_col, regular_user):
+        oid = ObjectId()
+        ce_mock_col.insert_one.return_value = MagicMock(inserted_id=oid)
+
+        resp = ce_client.post("/copy-events", json={
+            "quiz_id": "base", "question_id": "q1", "conversation_id": "conv1",
+            "copied_text": "The answer is 4.",
+        })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["copied_text"] == "The answer is 4."
+        assert data["user_id"] == regular_user.id
+
+    def test_missing_copied_text_returns_422(self, ce_client):
+        resp = ce_client.post("/copy-events", json={})
+        assert resp.status_code == 422
+
+    def test_empty_copied_text_returns_422(self, ce_client):
+        resp = ce_client.post("/copy-events", json={"copied_text": ""})
+        assert resp.status_code == 422
+
+    def test_overlong_copied_text_returns_422(self, ce_client):
+        resp = ce_client.post("/copy-events", json={"copied_text": "x" * 2001})
+        assert resp.status_code == 422
+
+    def test_requires_authentication(self):
+        app = FastAPI()
+        app.include_router(copy_events_router)
+        app.state.db = MagicMock()
+        client = TestClient(app)
+
+        resp = client.post("/copy-events", json={"copied_text": "hi"})
+        assert resp.status_code != 200
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /copy-events
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestGetCopyEvents:
+    def test_regular_user_scoped_to_own_events(self, ce_client, ce_mock_col, regular_user):
+        ce_mock_col.find.return_value.sort.return_value = []
+
+        resp = ce_client.get("/copy-events")
+
+        assert resp.status_code == 200
+        ce_mock_col.find.assert_called_once_with({"user_id": regular_user.id})
+
+    def test_admin_sees_all_events(self, ce_admin_client, ce_mock_col):
+        ce_mock_col.find.return_value.sort.return_value = []
+
+        resp = ce_admin_client.get("/copy-events")
+
+        assert resp.status_code == 200
+        ce_mock_col.find.assert_called_once_with({})

--- a/backend/tests/test_copy_events_service.py
+++ b/backend/tests/test_copy_events_service.py
@@ -1,0 +1,75 @@
+# backend/tests/test_copy_events_service.py
+"""Unit tests for app.services.copy_events: CRUD backed by a mocked collection."""
+from unittest.mock import MagicMock
+from bson import ObjectId
+import pytest
+
+from app.schemas.copy_event import CopyEventCreate
+from app.schemas.user import UserPublic
+from app.services.copy_events import (
+    get_copy_events_collection,
+    ensure_indexes,
+    create_copy_event,
+    list_copy_events,
+)
+
+
+@pytest.fixture
+def user():
+    return UserPublic(id="u1", email="student@test.edu", is_admin=False)
+
+
+class TestGetCopyEventsCollection:
+    def test_returns_copy_events_collection(self, mock_db, mock_col):
+        result = get_copy_events_collection(mock_db)
+        assert result is mock_col
+        mock_db.__getitem__.assert_called_with("copy_events")
+
+
+class TestEnsureIndexes:
+    def test_creates_expected_indexes(self, mock_col):
+        ensure_indexes(mock_col)
+        mock_col.create_index.assert_any_call("user_id")
+        mock_col.create_index.assert_any_call("conversation_id")
+        mock_col.create_index.assert_any_call([("created_at", -1)])
+
+
+class TestCreateCopyEvent:
+    def test_stores_all_fields(self, mock_col, user):
+        oid = ObjectId()
+        mock_col.insert_one.return_value = MagicMock(inserted_id=oid)
+        data = CopyEventCreate(
+            quiz_id="base", question_id="q1", conversation_id="conv1",
+            copied_text="The probability is 1/6.",
+        )
+
+        result = create_copy_event(mock_col, user, data)
+
+        assert result.id == str(oid)
+        assert result.user_id == "u1"
+        assert result.user_email == "student@test.edu"
+        assert result.copied_text == "The probability is 1/6."
+        assert result.created_at is not None
+
+    def test_optional_fields_default_to_none(self, mock_col, user):
+        oid = ObjectId()
+        mock_col.insert_one.return_value = MagicMock(inserted_id=oid)
+        data = CopyEventCreate(copied_text="some text")
+
+        result = create_copy_event(mock_col, user, data)
+
+        assert result.quiz_id is None
+        assert result.question_id is None
+        assert result.conversation_id is None
+
+
+class TestListCopyEvents:
+    def test_no_user_id_returns_all(self, mock_col):
+        mock_col.find.return_value.sort.return_value = []
+        list_copy_events(mock_col)
+        mock_col.find.assert_called_once_with({})
+
+    def test_user_id_scopes_query(self, mock_col):
+        mock_col.find.return_value.sort.return_value = []
+        list_copy_events(mock_col, user_id="u1")
+        mock_col.find.assert_called_once_with({"user_id": "u1"})

--- a/backend/tests/test_link_clicks_api.py
+++ b/backend/tests/test_link_clicks_api.py
@@ -1,0 +1,108 @@
+# backend/tests/test_link_clicks_api.py
+"""FastAPI TestClient integration tests for app.api.link_clicks."""
+from unittest.mock import MagicMock
+
+import pytest
+from bson import ObjectId
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.link_clicks import router as link_clicks_router
+from app.api.auth import get_current_user
+
+
+# ── Local app/fixtures (do not touch conftest.py) ────────────────────────────
+
+@pytest.fixture
+def lc_mock_col():
+    return MagicMock()
+
+
+@pytest.fixture
+def lc_mock_db(lc_mock_col):
+    db = MagicMock()
+    db.__getitem__ = MagicMock(return_value=lc_mock_col)
+    return db
+
+
+@pytest.fixture
+def lc_app(lc_mock_db, regular_user):
+    app = FastAPI()
+    app.include_router(link_clicks_router)
+    app.state.db = lc_mock_db
+    app.dependency_overrides[get_current_user] = lambda: regular_user
+    return app
+
+
+@pytest.fixture
+def lc_client(lc_app):
+    return TestClient(lc_app)
+
+
+@pytest.fixture
+def lc_admin_app(lc_mock_db, admin_user):
+    app = FastAPI()
+    app.include_router(link_clicks_router)
+    app.state.db = lc_mock_db
+    app.dependency_overrides[get_current_user] = lambda: admin_user
+    return app
+
+
+@pytest.fixture
+def lc_admin_client(lc_admin_app):
+    return TestClient(lc_admin_app)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# POST /links/clicks
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRecordLinkClick:
+    def test_succeeds_for_regular_user_no_admin_required(self, lc_client, lc_mock_col, regular_user):
+        oid = ObjectId()
+        lc_mock_col.insert_one.return_value = MagicMock(inserted_id=oid)
+
+        resp = lc_client.post("/links/clicks", json={
+            "quiz_id": "links", "question_id": "q1", "conversation_id": "conv1",
+            "url": "https://example.com/article",
+        })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["url"] == "https://example.com/article"
+        assert data["user_id"] == regular_user.id
+
+    def test_missing_url_returns_422(self, lc_client):
+        resp = lc_client.post("/links/clicks", json={})
+        assert resp.status_code == 422
+
+    def test_requires_authentication(self):
+        app = FastAPI()
+        app.include_router(link_clicks_router)
+        app.state.db = MagicMock()
+        client = TestClient(app)
+
+        resp = client.post("/links/clicks", json={"url": "https://example.com"})
+        assert resp.status_code != 200
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /links/clicks
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestGetLinkClicks:
+    def test_regular_user_scoped_to_own_clicks(self, lc_client, lc_mock_col, regular_user):
+        lc_mock_col.find.return_value.sort.return_value = []
+
+        resp = lc_client.get("/links/clicks")
+
+        assert resp.status_code == 200
+        lc_mock_col.find.assert_called_once_with({"user_id": regular_user.id})
+
+    def test_admin_sees_all_clicks(self, lc_admin_client, lc_mock_col):
+        lc_mock_col.find.return_value.sort.return_value = []
+
+        resp = lc_admin_client.get("/links/clicks")
+
+        assert resp.status_code == 200
+        lc_mock_col.find.assert_called_once_with({})

--- a/backend/tests/test_link_clicks_service.py
+++ b/backend/tests/test_link_clicks_service.py
@@ -1,0 +1,82 @@
+# backend/tests/test_link_clicks_service.py
+"""Unit tests for app.services.link_clicks: CRUD backed by a mocked collection."""
+from unittest.mock import MagicMock
+from bson import ObjectId
+import pytest
+
+from app.schemas.link_click import LinkClickCreate
+from app.schemas.user import UserPublic
+from app.services.link_clicks import (
+    get_link_clicks_collection,
+    ensure_indexes,
+    create_link_click,
+    list_link_clicks,
+)
+
+
+@pytest.fixture
+def user():
+    return UserPublic(id="u1", email="student@test.edu", is_admin=False)
+
+
+class TestGetLinkClicksCollection:
+    def test_returns_link_clicks_collection(self, mock_db, mock_col):
+        result = get_link_clicks_collection(mock_db)
+        assert result is mock_col
+        mock_db.__getitem__.assert_called_with("link_clicks")
+
+
+class TestEnsureIndexes:
+    def test_creates_expected_indexes(self, mock_col):
+        ensure_indexes(mock_col)
+        mock_col.create_index.assert_any_call("user_id")
+        mock_col.create_index.assert_any_call("conversation_id")
+        mock_col.create_index.assert_any_call([("clicked_at", -1)])
+
+
+class TestCreateLinkClick:
+    def test_stores_all_fields(self, mock_col, user):
+        oid = ObjectId()
+        mock_col.insert_one.return_value = MagicMock(inserted_id=oid)
+        data = LinkClickCreate(
+            quiz_id="links", question_id="q1", conversation_id="conv1",
+            url="https://example.com/article",
+        )
+
+        result = create_link_click(mock_col, user, data)
+
+        assert result.id == str(oid)
+        assert result.user_id == "u1"
+        assert result.user_email == "student@test.edu"
+        assert result.quiz_id == "links"
+        assert result.question_id == "q1"
+        assert result.conversation_id == "conv1"
+        assert result.url == "https://example.com/article"
+        assert result.clicked_at is not None
+
+        inserted = mock_col.insert_one.call_args[0][0]
+        assert inserted["user_id"] == "u1"
+        assert inserted["url"] == "https://example.com/article"
+
+    def test_optional_fields_default_to_none(self, mock_col, user):
+        oid = ObjectId()
+        mock_col.insert_one.return_value = MagicMock(inserted_id=oid)
+        data = LinkClickCreate(url="https://example.com")
+
+        result = create_link_click(mock_col, user, data)
+
+        assert result.quiz_id is None
+        assert result.question_id is None
+        assert result.conversation_id is None
+
+
+class TestListLinkClicks:
+    def test_no_user_id_returns_all(self, mock_col):
+        mock_col.find.return_value.sort.return_value = []
+        list_link_clicks(mock_col)
+        mock_col.find.assert_called_once_with({})
+
+    def test_user_id_scopes_query(self, mock_col):
+        mock_col.find.return_value.sort.return_value = []
+        list_link_clicks(mock_col, user_id="u1")
+        mock_col.find.assert_called_once_with({"user_id": "u1"})

--- a/backend/tests/test_reports_api.py
+++ b/backend/tests/test_reports_api.py
@@ -1,0 +1,225 @@
+# backend/tests/test_reports_api.py
+"""FastAPI TestClient integration tests for app.api.reports."""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from bson import ObjectId
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.reports import router as reports_router
+from app.api.auth import get_current_user
+
+
+# ── Local app/fixtures (do not touch conftest.py) ────────────────────────────
+
+@pytest.fixture
+def rp_mock_col():
+    return MagicMock()
+
+
+@pytest.fixture
+def rp_mock_db(rp_mock_col):
+    db = MagicMock()
+    db.__getitem__ = MagicMock(return_value=rp_mock_col)
+    return db
+
+
+@pytest.fixture
+def rp_app(rp_mock_db, regular_user):
+    app = FastAPI()
+    app.include_router(reports_router)
+    app.state.db = rp_mock_db
+    app.dependency_overrides[get_current_user] = lambda: regular_user
+    return app
+
+
+@pytest.fixture
+def rp_client(rp_app):
+    return TestClient(rp_app)
+
+
+@pytest.fixture
+def rp_admin_app(rp_mock_db, admin_user):
+    app = FastAPI()
+    app.include_router(reports_router)
+    app.state.db = rp_mock_db
+    app.dependency_overrides[get_current_user] = lambda: admin_user
+    return app
+
+
+@pytest.fixture
+def rp_admin_client(rp_admin_app):
+    return TestClient(rp_admin_app)
+
+
+def make_report_doc(_id=None, **overrides):
+    doc = {
+        "_id": _id if _id is not None else ObjectId(),
+        "user_id": "userid1",
+        "user_email": "student@test.edu",
+        "quiz_id": "base",
+        "question_id": "q1",
+        "category": "bug",
+        "description": "The submit button did nothing.",
+        "status": "open",
+        "comments": [],
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    doc.update(overrides)
+    return doc
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# POST /reports
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestSubmitReport:
+    def test_succeeds_for_regular_user(self, rp_client, rp_mock_col, regular_user):
+        oid = ObjectId()
+        rp_mock_col.insert_one.return_value = MagicMock(inserted_id=oid)
+
+        resp = rp_client.post("/reports", json={
+            "category": "bug", "description": "Broken choice", "quiz_id": "base", "question_id": "q1",
+        })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_email"] == regular_user.email
+        assert data["status"] == "open"
+
+    def test_missing_description_returns_422(self, rp_client):
+        resp = rp_client.post("/reports", json={"category": "bug"})
+        assert resp.status_code == 422
+
+    def test_invalid_category_returns_422(self, rp_client):
+        resp = rp_client.post("/reports", json={"category": "not-a-category", "description": "x"})
+        assert resp.status_code == 422
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /reports
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestGetReports:
+    def test_regular_user_scoped_to_own_reports(self, rp_client, rp_mock_col, regular_user):
+        rp_mock_col.find.return_value.sort.return_value = []
+
+        resp = rp_client.get("/reports")
+
+        assert resp.status_code == 200
+        rp_mock_col.find.assert_called_once_with({"user_id": regular_user.id})
+
+    def test_admin_sees_all_reports(self, rp_admin_client, rp_mock_col):
+        rp_mock_col.find.return_value.sort.return_value = []
+
+        resp = rp_admin_client.get("/reports")
+
+        assert resp.status_code == 200
+        rp_mock_col.find.assert_called_once_with({})
+
+    def test_status_query_param_passed_through(self, rp_client, rp_mock_col, regular_user):
+        rp_mock_col.find.return_value.sort.return_value = []
+
+        rp_client.get("/reports?status=open")
+
+        rp_mock_col.find.assert_called_once_with({"user_id": regular_user.id, "status": "open"})
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# GET /reports/{report_id}
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestGetSingleReport:
+    def test_owner_can_view_own_report(self, rp_client, rp_mock_col, regular_user):
+        oid = ObjectId()
+        rp_mock_col.find_one.return_value = make_report_doc(_id=oid, user_id=regular_user.id)
+
+        resp = rp_client.get(f"/reports/{oid}")
+
+        assert resp.status_code == 200
+
+    def test_other_users_report_returns_404(self, rp_client, rp_mock_col):
+        oid = ObjectId()
+        # Scoped query (user_id filter) won't match someone else's report.
+        rp_mock_col.find_one.return_value = None
+
+        resp = rp_client.get(f"/reports/{oid}")
+
+        assert resp.status_code == 404
+
+    def test_admin_can_view_any_report(self, rp_admin_client, rp_mock_col):
+        oid = ObjectId()
+        rp_mock_col.find_one.return_value = make_report_doc(_id=oid, user_id="someone-else")
+
+        resp = rp_admin_client.get(f"/reports/{oid}")
+
+        assert resp.status_code == 200
+
+    def test_invalid_id_returns_404(self, rp_client):
+        resp = rp_client.get("/reports/not-a-real-id")
+        assert resp.status_code == 404
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# POST /reports/{report_id}/comments
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestAddReportComment:
+    def test_owner_can_comment_on_own_report(self, rp_client, rp_mock_col, regular_user):
+        oid = ObjectId()
+        rp_mock_col.update_one.return_value = MagicMock(matched_count=1)
+        rp_mock_col.find_one.return_value = make_report_doc(_id=oid, user_id=regular_user.id)
+
+        resp = rp_client.post(f"/reports/{oid}/comments", json={"body": "Still broken."})
+
+        assert resp.status_code == 200
+
+    def test_other_users_report_returns_404(self, rp_client, rp_mock_col):
+        oid = ObjectId()
+        rp_mock_col.update_one.return_value = MagicMock(matched_count=0)
+
+        resp = rp_client.post(f"/reports/{oid}/comments", json={"body": "Still broken."})
+
+        assert resp.status_code == 404
+
+    def test_empty_body_returns_422(self, rp_client):
+        oid = ObjectId()
+        resp = rp_client.post(f"/reports/{oid}/comments", json={"body": ""})
+        assert resp.status_code == 422
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PATCH /reports/{report_id}/status
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestPatchReportStatus:
+    def test_admin_can_update_status(self, rp_admin_client, rp_mock_col):
+        oid = ObjectId()
+        rp_mock_col.update_one.return_value = MagicMock(matched_count=1)
+        rp_mock_col.find_one.return_value = make_report_doc(_id=oid, status="resolved")
+
+        resp = rp_admin_client.patch(f"/reports/{oid}/status", json={"status": "resolved"})
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "resolved"
+
+    def test_regular_user_forbidden(self, rp_client):
+        oid = ObjectId()
+        resp = rp_client.patch(f"/reports/{oid}/status", json={"status": "resolved"})
+        assert resp.status_code == 403
+
+    def test_not_found_returns_404(self, rp_admin_client, rp_mock_col):
+        oid = ObjectId()
+        rp_mock_col.update_one.return_value = MagicMock(matched_count=0)
+
+        resp = rp_admin_client.patch(f"/reports/{oid}/status", json={"status": "resolved"})
+
+        assert resp.status_code == 404
+
+    def test_invalid_status_returns_422(self, rp_admin_client):
+        oid = ObjectId()
+        resp = rp_admin_client.patch(f"/reports/{oid}/status", json={"status": "not-a-status"})
+        assert resp.status_code == 422

--- a/backend/tests/test_reports_service.py
+++ b/backend/tests/test_reports_service.py
@@ -1,0 +1,191 @@
+# backend/tests/test_reports_service.py
+"""Unit tests for app.services.reports: CRUD + ownership-scoping backed by a mocked collection."""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from bson import ObjectId
+import pytest
+
+from app.schemas.report import ReportCreate, ReportStatus, ReportCategory
+from app.schemas.user import UserPublic
+from app.services.reports import (
+    get_reports_collection,
+    ensure_indexes,
+    create_report,
+    list_reports,
+    get_report,
+    add_comment,
+    update_status,
+    _to_public,
+)
+
+
+@pytest.fixture
+def user():
+    return UserPublic(id="u1", email="student@test.edu", is_admin=False)
+
+
+@pytest.fixture
+def admin():
+    return UserPublic(id="admin1", email="admin@test.edu", is_admin=True)
+
+
+def make_report_doc(_id=None, **overrides):
+    doc = {
+        "_id": _id if _id is not None else ObjectId(),
+        "user_id": "u1",
+        "user_email": "student@test.edu",
+        "quiz_id": "base",
+        "question_id": "q1",
+        "category": "bug",
+        "description": "The submit button did nothing.",
+        "status": "open",
+        "comments": [],
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    doc.update(overrides)
+    return doc
+
+
+class TestGetReportsCollection:
+    def test_returns_reports_collection(self, mock_db, mock_col):
+        result = get_reports_collection(mock_db)
+        assert result is mock_col
+        mock_db.__getitem__.assert_called_with("reports")
+
+
+class TestEnsureIndexes:
+    def test_creates_expected_indexes(self, mock_col):
+        ensure_indexes(mock_col)
+        mock_col.create_index.assert_any_call("user_id")
+        mock_col.create_index.assert_any_call("status")
+        mock_col.create_index.assert_any_call([("created_at", -1)])
+
+
+class TestToPublic:
+    def test_invalid_category_falls_back_to_other(self):
+        doc = make_report_doc(category="not-a-real-category")
+        pub = _to_public(doc)
+        assert pub.category == ReportCategory.OTHER
+
+    def test_invalid_status_falls_back_to_open(self):
+        doc = make_report_doc(status="not-a-real-status")
+        pub = _to_public(doc)
+        assert pub.status == ReportStatus.OPEN
+
+    def test_comments_converted(self):
+        now = datetime.now(timezone.utc)
+        doc = make_report_doc(comments=[
+            {"id": "c1", "author_email": "admin@test.edu", "is_admin": True, "body": "Looking into it.", "created_at": now},
+        ])
+        pub = _to_public(doc)
+        assert len(pub.comments) == 1
+        assert pub.comments[0].author_email == "admin@test.edu"
+        assert pub.comments[0].is_admin is True
+
+
+class TestCreateReport:
+    def test_stores_open_status_and_empty_comments(self, mock_col, user):
+        oid = ObjectId()
+        mock_col.insert_one.return_value = MagicMock(inserted_id=oid)
+        data = ReportCreate(category=ReportCategory.BUG, description="  Broken choice  ", quiz_id="base", question_id="q1")
+
+        result = create_report(mock_col, user, data)
+
+        assert result.id == str(oid)
+        assert result.status == ReportStatus.OPEN
+        assert result.description == "Broken choice"
+        assert result.comments == []
+
+        inserted = mock_col.insert_one.call_args[0][0]
+        assert inserted["category"] == "bug"
+        assert inserted["status"] == "open"
+
+
+class TestListReports:
+    def test_no_filters_returns_all(self, mock_col):
+        mock_col.find.return_value.sort.return_value = []
+        list_reports(mock_col)
+        mock_col.find.assert_called_once_with({})
+
+    def test_user_id_and_status_scope_query(self, mock_col):
+        mock_col.find.return_value.sort.return_value = []
+        list_reports(mock_col, user_id="u1", status="open")
+        mock_col.find.assert_called_once_with({"user_id": "u1", "status": "open"})
+
+
+class TestGetReport:
+    def test_invalid_object_id_returns_none(self, mock_col):
+        assert get_report(mock_col, "not-an-oid") is None
+
+    def test_found_without_user_id_scope(self, mock_col):
+        oid = ObjectId()
+        mock_col.find_one.return_value = make_report_doc(_id=oid)
+        result = get_report(mock_col, str(oid))
+        assert result is not None
+        mock_col.find_one.assert_called_once_with({"_id": oid})
+
+    def test_scoped_query_includes_user_id(self, mock_col):
+        oid = ObjectId()
+        mock_col.find_one.return_value = make_report_doc(_id=oid)
+        get_report(mock_col, str(oid), user_id="u1")
+        mock_col.find_one.assert_called_once_with({"_id": oid, "user_id": "u1"})
+
+    def test_not_found_returns_none(self, mock_col):
+        oid = ObjectId()
+        mock_col.find_one.return_value = None
+        assert get_report(mock_col, str(oid)) is None
+
+
+class TestAddComment:
+    def test_invalid_object_id_returns_none(self, mock_col, user):
+        assert add_comment(mock_col, "not-an-oid", user, "body") is None
+
+    def test_no_match_returns_none(self, mock_col, user):
+        oid = ObjectId()
+        mock_col.update_one.return_value = MagicMock(matched_count=0)
+        assert add_comment(mock_col, str(oid), user, "body") is None
+
+    def test_comment_pushed_with_author_and_admin_flag(self, mock_col, admin):
+        oid = ObjectId()
+        mock_col.update_one.return_value = MagicMock(matched_count=1)
+        mock_col.find_one.return_value = make_report_doc(_id=oid)
+
+        add_comment(mock_col, str(oid), admin, "  On it.  ")
+
+        args = mock_col.update_one.call_args[0]
+        assert args[0] == {"_id": oid}
+        pushed = args[1]["$push"]["comments"]
+        assert pushed["author_email"] == "admin@test.edu"
+        assert pushed["is_admin"] is True
+        assert pushed["body"] == "On it."
+
+    def test_ownership_scoped_query_when_user_id_given(self, mock_col, user):
+        oid = ObjectId()
+        mock_col.update_one.return_value = MagicMock(matched_count=1)
+        mock_col.find_one.return_value = make_report_doc(_id=oid)
+
+        add_comment(mock_col, str(oid), user, "body", user_id="u1")
+
+        args = mock_col.update_one.call_args[0]
+        assert args[0] == {"_id": oid, "user_id": "u1"}
+
+
+class TestUpdateStatus:
+    def test_invalid_object_id_returns_none(self, mock_col):
+        assert update_status(mock_col, "not-an-oid", ReportStatus.RESOLVED) is None
+
+    def test_no_match_returns_none(self, mock_col):
+        oid = ObjectId()
+        mock_col.update_one.return_value = MagicMock(matched_count=0)
+        assert update_status(mock_col, str(oid), ReportStatus.RESOLVED) is None
+
+    def test_sets_status_value_not_enum(self, mock_col):
+        oid = ObjectId()
+        mock_col.update_one.return_value = MagicMock(matched_count=1)
+        mock_col.find_one.return_value = make_report_doc(_id=oid, status="resolved")
+
+        update_status(mock_col, str(oid), ReportStatus.RESOLVED)
+
+        args = mock_col.update_one.call_args[0]
+        assert args[1]["$set"]["status"] == "resolved"

--- a/backend/tests/test_users_service.py
+++ b/backend/tests/test_users_service.py
@@ -1,6 +1,6 @@
 # backend/tests/test_users_service.py
 """Unit tests for app.services.users: user CRUD/lookup helpers backed by a mocked collection."""
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,6 +15,7 @@ from app.services.users import (
     create_user,
     find_user_by_email,
     check_user_password,
+    maybe_touch_last_active,
     _next_assigned_var,
     _normalize_stage,
     _to_public,
@@ -263,3 +264,55 @@ class TestCheckUserPassword:
     def test_wrong_password_returns_false(self):
         user_doc = {"password_hash": hash_password("correct-password")}
         assert check_user_password(user_doc, "wrong-password") is False
+
+
+# ── maybe_touch_last_active ──────────────────────────────────────────────────
+
+class TestMaybeTouchLastActive:
+    def test_missing_last_active_at_updates(self, mock_col):
+        oid = ObjectId()
+        doc = {"_id": oid}
+
+        maybe_touch_last_active(mock_col, doc)
+
+        mock_col.update_one.assert_called_once()
+        args = mock_col.update_one.call_args[0]
+        assert args[0] == {"_id": oid}
+        assert "last_active_at" in args[1]["$set"]
+
+    def test_recent_value_does_not_update(self, mock_col):
+        oid = ObjectId()
+        doc = {"_id": oid, "last_active_at": datetime.now(timezone.utc) - timedelta(seconds=5)}
+
+        maybe_touch_last_active(mock_col, doc)
+
+        mock_col.update_one.assert_not_called()
+
+    def test_stale_value_updates(self, mock_col):
+        oid = ObjectId()
+        doc = {"_id": oid, "last_active_at": datetime.now(timezone.utc) - timedelta(minutes=10)}
+
+        maybe_touch_last_active(mock_col, doc)
+
+        mock_col.update_one.assert_called_once()
+
+    def test_naive_datetime_from_mongo_round_trip_does_not_raise(self, mock_col):
+        """pymongo returns stored datetimes as naive UTC by default. A recent
+        naive value must be treated as recent, not raise on subtraction."""
+        oid = ObjectId()
+        naive_recent = datetime.utcnow() - timedelta(seconds=5)
+        assert naive_recent.tzinfo is None
+        doc = {"_id": oid, "last_active_at": naive_recent}
+
+        maybe_touch_last_active(mock_col, doc)  # must not raise
+
+        mock_col.update_one.assert_not_called()
+
+    def test_naive_stale_datetime_updates(self, mock_col):
+        oid = ObjectId()
+        naive_stale = datetime.utcnow() - timedelta(minutes=10)
+        doc = {"_id": oid, "last_active_at": naive_stale}
+
+        maybe_touch_last_active(mock_col, doc)
+
+        mock_col.update_one.assert_called_once()

--- a/frontend/__tests__/components/ChatBox.test.tsx
+++ b/frontend/__tests__/components/ChatBox.test.tsx
@@ -4,10 +4,20 @@ import type { SendChatOptions, ChatResponse } from "../../lib/chat";
 
 const mockSendChat = jest.fn();
 const mockLoadUserHistory = jest.fn();
+const mockRecordLinkClick = jest.fn();
+const mockRecordCopyEvent = jest.fn();
 
 jest.mock("../../lib/chat", () => ({
   sendChat: (...args: unknown[]) => mockSendChat(...args),
   loadUserHistory: (...args: unknown[]) => mockLoadUserHistory(...args),
+}));
+
+jest.mock("../../lib/linkClicks", () => ({
+  recordLinkClick: (...args: unknown[]) => mockRecordLinkClick(...args),
+}));
+
+jest.mock("../../lib/copyEvents", () => ({
+  recordCopyEvent: (...args: unknown[]) => mockRecordCopyEvent(...args),
 }));
 
 const PLACEHOLDER = "Type a message…";
@@ -18,6 +28,10 @@ describe("ChatBox", () => {
     mockSendChat.mockReset();
     mockLoadUserHistory.mockReset();
     mockLoadUserHistory.mockResolvedValue({ conversation_id: "", messages: [] });
+    mockRecordLinkClick.mockReset();
+    mockRecordLinkClick.mockResolvedValue(undefined);
+    mockRecordCopyEvent.mockReset();
+    mockRecordCopyEvent.mockResolvedValue(undefined);
   });
 
   it("renders the header and a disabled Send button when the input is empty", () => {
@@ -301,5 +315,152 @@ describe("ChatBox", () => {
     expect(await screen.findByText("Old question")).toBeInTheDocument();
     expect(screen.queryByText("First reply")).not.toBeInTheDocument();
     expect(mockLoadUserHistory).toHaveBeenCalledWith("conv-2");
+  });
+
+  // ── question_id / trigger plumbing ──────────────────────────────────────
+
+  it("sends trigger='manual' and the questionId prop for a manually typed message", async () => {
+    mockSendChat.mockImplementation(() => new Promise<ChatResponse>(() => {}));
+
+    render(<ChatBox quizId="base" questionId="q1" />);
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(mockSendChat).toHaveBeenCalledWith(
+      "base", null, "Hello", [],
+      expect.objectContaining({ questionId: "q1", trigger: "manual" })
+    );
+  });
+
+  it("sends trigger='followup_chip' when a follow-up chip is clicked", async () => {
+    let capturedOptions: SendChatOptions = {};
+    let resolveSend: (value: ChatResponse) => void = () => {};
+    mockSendChat.mockImplementationOnce((_q, _c, _m, _a, options: SendChatOptions) => {
+      capturedOptions = options;
+      return new Promise<ChatResponse>((resolve) => { resolveSend = resolve; });
+    });
+
+    render(<ChatBox quizId="base" />);
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    act(() => { capturedOptions.onDone?.(["Main reply"], "conv-1"); });
+    await screen.findByText("Main reply");
+
+    act(() => { capturedOptions.onFollowupToken?.("1. What is X?\n"); });
+    await screen.findByText("What is X?");
+
+    act(() => {
+      resolveSend({ replies: ["Main reply"], conversationId: "conv-1", followupQuestions: undefined });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument());
+
+    mockSendChat.mockImplementationOnce(() => new Promise<ChatResponse>(() => {}));
+    fireEvent.click(screen.getByText("What is X?"));
+
+    await waitFor(() =>
+      expect(mockSendChat).toHaveBeenCalledWith(
+        "base", "conv-1", "What is X?", [],
+        expect.objectContaining({ trigger: "followup_chip" })
+      )
+    );
+  });
+
+  it("sends trigger='auto_question' for an externalQuestion auto-send", async () => {
+    mockSendChat.mockImplementation(() => new Promise<ChatResponse>(() => {}));
+
+    const { rerender } = render(<ChatBox quizId="base" externalQuestion={null} />);
+    rerender(<ChatBox quizId="base" externalQuestion="What is the meaning of life?" />);
+
+    await waitFor(() =>
+      expect(mockSendChat).toHaveBeenCalledWith(
+        "base", null, "What is the meaning of life?", [],
+        expect.objectContaining({ trigger: "auto_question" })
+      )
+    );
+  });
+
+  // ── link click tracking (links variant) ─────────────────────────────────
+
+  it("records a link click for an assistant message in the links variant", async () => {
+    mockSendChat.mockImplementation(async (_q, _c, _m, _a, options: SendChatOptions) => {
+      options.onDone?.(["See [source](https://example.com/article) for more."], "conv-1");
+      return { replies: ["See [source](https://example.com/article) for more."], conversationId: "conv-1", followupQuestions: undefined } as ChatResponse;
+    });
+
+    render(<ChatBox quizId="links" questionId="q1" conversationId="conv-1" />);
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    const link = await screen.findByRole("link", { name: "source" });
+    fireEvent.click(link);
+
+    expect(mockRecordLinkClick).toHaveBeenCalledWith({
+      quiz_id: "links",
+      question_id: "q1",
+      conversation_id: "conv-1",
+      url: "https://example.com/article",
+    });
+  });
+
+  it("does not record a link click for a non-links variant", async () => {
+    mockSendChat.mockImplementation(async (_q, _c, _m, _a, options: SendChatOptions) => {
+      options.onDone?.(["See [source](https://example.com/article) for more."], "conv-1");
+      return { replies: ["See [source](https://example.com/article) for more."], conversationId: "conv-1", followupQuestions: undefined } as ChatResponse;
+    });
+
+    render(<ChatBox quizId="base" conversationId="conv-1" />);
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    const link = await screen.findByRole("link", { name: "source" });
+    fireEvent.click(link);
+
+    expect(mockRecordLinkClick).not.toHaveBeenCalled();
+  });
+
+  // ── copy event tracking ──────────────────────────────────────────────────
+
+  it("records a copy event with the selected text from the chat pane", async () => {
+    mockSendChat.mockImplementation(async (_q, _c, _m, _a, options: SendChatOptions) => {
+      options.onDone?.(["Hi there!"], "conv-1");
+      return { replies: ["Hi there!"], conversationId: "conv-1", followupQuestions: undefined } as ChatResponse;
+    });
+
+    const { container } = render(<ChatBox quizId="base" questionId="q1" />);
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await screen.findByText("Hi there!");
+
+    const getSelectionSpy = jest.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "Hi there!",
+    } as Selection);
+
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    fireEvent.copy(scroller);
+
+    expect(mockRecordCopyEvent).toHaveBeenCalledWith({
+      quiz_id: "base",
+      question_id: "q1",
+      conversation_id: "conv-1",
+      copied_text: "Hi there!",
+    });
+
+    getSelectionSpy.mockRestore();
+  });
+
+  it("does not record a copy event when there is no selected text", async () => {
+    const { container } = render(<ChatBox quizId="base" />);
+
+    const getSelectionSpy = jest.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "",
+    } as Selection);
+
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    fireEvent.copy(scroller);
+
+    expect(mockRecordCopyEvent).not.toHaveBeenCalled();
+
+    getSelectionSpy.mockRestore();
   });
 });

--- a/frontend/__tests__/components/MarkdownMessage.test.tsx
+++ b/frontend/__tests__/components/MarkdownMessage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import MarkdownMessage from "../../components/MarkdownMessage";
 
 describe("MarkdownMessage", () => {
@@ -149,5 +149,37 @@ describe("MarkdownMessage", () => {
     expect(container.querySelector("span")).not.toBeNull();
     expect(container.querySelector("p")).toBeNull();
     expect(container.textContent).toBe("just text");
+  });
+
+  it("calls onLinkClick with the href when a link is clicked", () => {
+    const onLinkClick = jest.fn();
+    render(<MarkdownMessage content="[Example](https://example.com)" onLinkClick={onLinkClick} />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Example" }));
+
+    expect(onLinkClick).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("calls onLinkClick in dark mode too", () => {
+    const onLinkClick = jest.fn();
+    render(<MarkdownMessage content="[Example](https://example.com)" dark onLinkClick={onLinkClick} />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Example" }));
+
+    expect(onLinkClick).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("calls onLinkClick in inline mode too", () => {
+    const onLinkClick = jest.fn();
+    render(<MarkdownMessage content="[Example](https://example.com)" inline onLinkClick={onLinkClick} />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Example" }));
+
+    expect(onLinkClick).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("does not throw when a link is clicked and no onLinkClick is provided", () => {
+    render(<MarkdownMessage content="[Example](https://example.com)" />);
+    expect(() => fireEvent.click(screen.getByRole("link", { name: "Example" }))).not.toThrow();
   });
 });

--- a/frontend/__tests__/lib/auth.test.ts
+++ b/frontend/__tests__/lib/auth.test.ts
@@ -5,6 +5,8 @@ import {
   getMe,
   invalidateMeCache,
   changePassword,
+  recordConsentAgreement,
+  recordConsentDecline,
 } from "../../lib/auth";
 
 function mockFetchOnce(body: unknown, ok = true, status = 200) {
@@ -70,6 +72,34 @@ describe("auth lib", () => {
     expect(global.fetch).toHaveBeenCalledWith(
       "/auth/logout",
       expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("recordConsentAgreement posts consent_text to /auth/consent", async () => {
+    mockFetchOnce({ ok: true });
+
+    await recordConsentAgreement("Research Consent Form ... I agree to participate");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/auth/consent",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ consent_text: "Research Consent Form ... I agree to participate" }),
+      })
+    );
+  });
+
+  it("recordConsentDecline posts consent_text to /auth/decline", async () => {
+    mockFetchOnce({ ok: true });
+
+    await recordConsentDecline("Research Consent Form ... I do not wish to participate");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/auth/decline",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ consent_text: "Research Consent Form ... I do not wish to participate" }),
+      })
     );
   });
 

--- a/frontend/__tests__/lib/chat.test.ts
+++ b/frontend/__tests__/lib/chat.test.ts
@@ -236,7 +236,46 @@ describe("sendChat", () => {
           agents: [],
           answer_incorrectly: true,
           answer_choices: [{ id: "c1", label: "Choice 1" }],
+          question_id: null,
+          trigger: null,
         }),
+      })
+    );
+  });
+
+  it("sends question_id and trigger in the request body when provided", async () => {
+    const chunks = [sseChunk([{ type: "done", conversation_id: "conv-7" }])];
+    (global.fetch as jest.Mock).mockResolvedValue(makeStreamingResponse(chunks));
+
+    await sendChat("base", "conv-7", "hi", [], {
+      questionId: "q1",
+      trigger: "followup_chip",
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/chat/base",
+      expect.objectContaining({
+        body: expect.stringContaining('"question_id":"q1"'),
+      })
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/chat/base",
+      expect.objectContaining({
+        body: expect.stringContaining('"trigger":"followup_chip"'),
+      })
+    );
+  });
+
+  it("sends null question_id and trigger when not provided", async () => {
+    const chunks = [sseChunk([{ type: "done", conversation_id: "conv-8" }])];
+    (global.fetch as jest.Mock).mockResolvedValue(makeStreamingResponse(chunks));
+
+    await sendChat("base", "conv-8", "hi");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/chat/base",
+      expect.objectContaining({
+        body: expect.stringContaining('"question_id":null'),
       })
     );
   });

--- a/frontend/__tests__/lib/copyEvents.test.ts
+++ b/frontend/__tests__/lib/copyEvents.test.ts
@@ -1,0 +1,35 @@
+import { recordCopyEvent, getCopyEvents } from "../../lib/copyEvents";
+
+describe("copyEvents lib", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => JSON.stringify({ ok: true }),
+    }) as jest.Mock;
+  });
+
+  it("recordCopyEvent posts to /api/copy-events with the copy payload", async () => {
+    const payload = { quiz_id: "base", question_id: "q1", conversation_id: "conv1", copied_text: "The answer is 4." };
+    await recordCopyEvent(payload);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/copy-events",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(payload),
+        credentials: "include",
+      })
+    );
+  });
+
+  it("getCopyEvents requests the copy-events endpoint", async () => {
+    await getCopyEvents();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/copy-events",
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+});

--- a/frontend/__tests__/lib/linkClicks.test.ts
+++ b/frontend/__tests__/lib/linkClicks.test.ts
@@ -1,0 +1,35 @@
+import { recordLinkClick, getLinkClicks } from "../../lib/linkClicks";
+
+describe("linkClicks lib", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => JSON.stringify({ ok: true }),
+    }) as jest.Mock;
+  });
+
+  it("recordLinkClick posts to /api/links/clicks with the click payload", async () => {
+    const payload = { quiz_id: "links", question_id: "q1", conversation_id: "conv1", url: "https://example.com" };
+    await recordLinkClick(payload);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/links/clicks",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(payload),
+        credentials: "include",
+      })
+    );
+  });
+
+  it("getLinkClicks requests the clicks endpoint", async () => {
+    await getLinkClicks();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/links/clicks",
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+});

--- a/frontend/__tests__/pages/consent.test.tsx
+++ b/frontend/__tests__/pages/consent.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ConsentPage from "../../pages/consent";
-import { getMe, invalidateMeCache, logout, recordConsentAgreement } from "../../lib/auth";
+import { getMe, invalidateMeCache, logout, recordConsentAgreement, recordConsentDecline } from "../../lib/auth";
 
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
@@ -13,12 +13,14 @@ jest.mock("../../lib/auth", () => ({
   logout: jest.fn(),
   invalidateMeCache: jest.fn(),
   recordConsentAgreement: jest.fn(),
+  recordConsentDecline: jest.fn(),
 }));
 
 const mockGetMe = getMe as jest.Mock;
 const mockLogout = logout as jest.Mock;
 const mockInvalidateMeCache = invalidateMeCache as jest.Mock;
 const mockRecordConsentAgreement = recordConsentAgreement as jest.Mock;
+const mockRecordConsentDecline = recordConsentDecline as jest.Mock;
 
 const authedUser = { id: "1", email: "user@example.com", is_admin: false };
 
@@ -31,6 +33,8 @@ describe("ConsentPage", () => {
     mockInvalidateMeCache.mockReset();
     mockRecordConsentAgreement.mockReset();
     mockRecordConsentAgreement.mockResolvedValue({ ok: true });
+    mockRecordConsentDecline.mockReset();
+    mockRecordConsentDecline.mockResolvedValue({ ok: true });
   });
 
   it("shows a loading state before the session check resolves", () => {
@@ -123,13 +127,18 @@ describe("ConsentPage", () => {
     expect(agreeButton).not.toBeDisabled();
   });
 
-  it("logs out and redirects to login when the user declines", async () => {
+  it("saves the displayed consent text, then logs out and redirects to login when the user declines", async () => {
     mockGetMe.mockResolvedValue({ user: authedUser });
     mockLogout.mockResolvedValue(undefined);
     render(<ConsentPage />);
 
     const declineButton = await screen.findByRole("button", { name: "I do not wish to participate" });
     fireEvent.click(declineButton);
+
+    await waitFor(() => expect(mockRecordConsentDecline).toHaveBeenCalled());
+    const savedText = mockRecordConsentDecline.mock.calls[0][0] as string;
+    expect(savedText).toContain("Research Consent Form");
+    expect(savedText).not.toContain("I do not wish to participate");
 
     await waitFor(() => expect(mockLogout).toHaveBeenCalled());
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
@@ -144,6 +153,19 @@ describe("ConsentPage", () => {
     const declineButton = await screen.findByRole("button", { name: "I do not wish to participate" });
     fireEvent.click(declineButton);
 
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
+  });
+
+  it("still logs out and redirects even if saving the decline record fails", async () => {
+    mockGetMe.mockResolvedValue({ user: authedUser });
+    mockLogout.mockResolvedValue(undefined);
+    mockRecordConsentDecline.mockRejectedValue(new Error("network error"));
+    render(<ConsentPage />);
+
+    const declineButton = await screen.findByRole("button", { name: "I do not wish to participate" });
+    fireEvent.click(declineButton);
+
+    await waitFor(() => expect(mockLogout).toHaveBeenCalled());
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
   });
 });

--- a/frontend/__tests__/pages/quiz/[quiz_id].test.tsx
+++ b/frontend/__tests__/pages/quiz/[quiz_id].test.tsx
@@ -396,6 +396,7 @@ describe("QuizPage ([quiz_id])", () => {
     expect(screen.getByText("Ask the assistant about this question")).toBeInTheDocument();
     expect(screen.getByText("(none)")).toBeInTheDocument();
     expect(lastChatBoxProps.answerIncorrectly).toBe(false);
+    expect(lastChatBoxProps.questionId).toBe("q1");
   });
 
   it("shows an error message when loading the quiz state fails", async () => {

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -1,6 +1,8 @@
 // frontend/components/ChatBox.tsx
-import { memo, useEffect, useRef, useState } from "react";
-import { sendChat, loadUserHistory } from "../lib/chat";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { sendChat, loadUserHistory, type ChatTrigger } from "../lib/chat";
+import { recordLinkClick } from "../lib/linkClicks";
+import { recordCopyEvent } from "../lib/copyEvents";
 import MarkdownMessage from "./MarkdownMessage";
 import MentionSuggestions from "./MentionSuggestions";
 import ChatHeader from "./ChatHeader";
@@ -39,6 +41,7 @@ const MessageBubble = memo(function MessageBubble({
   assistantAlign = "left",
   showLabel = true,
   labelAlign,
+  onLinkClick,
 }: {
   role: "user" | "assistant";
   content: string;
@@ -46,6 +49,7 @@ const MessageBubble = memo(function MessageBubble({
   assistantAlign?: "left" | "right";
   showLabel?: boolean;
   labelAlign?: "left" | "right" | "center";
+  onLinkClick?: (href: string) => void;
 }) {
   const label = role === "user" ? "You" : bot ? `Agent ${bot}` : "Assistant";
   const bubbleClass =
@@ -67,7 +71,7 @@ const MessageBubble = memo(function MessageBubble({
       )}
       <div className={`flex ${isRightAligned ? "justify-end" : "justify-start"}`}>
         <div className={`max-w-[95%] rounded-2xl px-4 py-2 ${bubbleClass}`}>
-          <MarkdownMessage content={content} dark={role === "user"} />
+          <MarkdownMessage content={content} dark={role === "user"} onLinkClick={onLinkClick} />
         </div>
       </div>
     </div>
@@ -87,6 +91,7 @@ type ChatBoxProps = {
   onToggleQuestion?: () => void;
   answerIncorrectly?: boolean;
   answerChoices?: { id: string; label: string }[];
+  questionId?: string;
 };
 
 export default function ChatBox({
@@ -102,6 +107,7 @@ export default function ChatBox({
   onToggleQuestion,
   answerIncorrectly = false,
   answerChoices,
+  questionId,
 }: ChatBoxProps) {
   const agentFilter: AgentFilter = quizId === "double" ? "double" : "base";
   const [messages, setMessages] = useState<Msg[]>([]);
@@ -118,6 +124,18 @@ export default function ChatBox({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const historyFetched = useRef(false);
+
+  // Only meaningful for the links variant — citation links are the only links
+  // the AI ever embeds. useCallback keeps the reference stable across renders
+  // so it doesn't defeat MessageBubble's memoization.
+  const handleLinkClick = useCallback((href: string) => {
+    recordLinkClick({
+      quiz_id: quizId,
+      question_id: questionId,
+      conversation_id: activeConvId ?? undefined,
+      url: href,
+    }).catch(() => {});
+  }, [quizId, questionId, activeConvId]);
   const [showMentions, setShowMentions] = useState(false);
   const [mentionIndex, setMentionIndex] = useState(0);
   const [filteredAgents, setFilteredAgents] = useState<string[]>([]);
@@ -193,6 +211,26 @@ export default function ChatBox({
     onLoadingChange?.(pending);
   }, [pending]);
 
+  // Tracks any text copied out of the chat pane (any bubble, not just assistant
+  // ones — simpler than walking up to find the nearest message's role, and
+  // avoids losing data; filter by role at analysis time if needed).
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    function onCopy() {
+      const text = window.getSelection()?.toString() ?? "";
+      if (!text.trim()) return;
+      recordCopyEvent({
+        quiz_id: quizId,
+        question_id: questionId,
+        conversation_id: activeConvId ?? undefined,
+        copied_text: text.slice(0, 2000),
+      }).catch(() => {});
+    }
+    el.addEventListener("copy", onCopy);
+    return () => el.removeEventListener("copy", onCopy);
+  }, [quizId, questionId, activeConvId]);
+
   // Add a chip for each newly completed question line (\n-terminated).
   // processedNewlinesRef tracks how many lines have already been turned into chips,
   // so we only look at the new lines on each run — no re-parsing of existing chips.
@@ -216,7 +254,7 @@ export default function ChatBox({
     processedNewlinesRef.current = completedCount;
   }, [followupStreamText]);
 
-  async function sendMessage(content: string) {
+  async function sendMessage(content: string, trigger: ChatTrigger = "manual") {
     const trimmed = content.trim();
     if (!trimmed) return;
 
@@ -294,6 +332,8 @@ export default function ChatBox({
           signal: controller.signal,
           answerIncorrectly,
           answerChoices,
+          questionId,
+          trigger,
           // onToken — streams main text at 60fps
           onToken: (delta, agent) => {
             const key = agent ?? "default";
@@ -442,12 +482,12 @@ export default function ChatBox({
     }
     if (externalQuestion === lastSentExternalRef.current) return;
     lastSentExternalRef.current = externalQuestion;
-    sendMessage(externalQuestion);
+    sendMessage(externalQuestion, "auto_question");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [externalQuestion]);
 
   function handleFollowupClick(question: string) {
-    void sendMessage(question);
+    void sendMessage(question, "followup_chip");
   }
 
   // Current in-progress follow-up question text (the incomplete last line).
@@ -471,7 +511,13 @@ export default function ChatBox({
   const renderMessages = () => {
     if (agentFilter !== "double") {
       return messages.map((m) => (
-        <MessageBubble key={m.id} role={m.role} content={m.content} bot={m.bot} />
+        <MessageBubble
+          key={m.id}
+          role={m.role}
+          content={m.content}
+          bot={m.bot}
+          onLinkClick={m.role === "assistant" && quizId === "links" ? handleLinkClick : undefined}
+        />
       ));
     }
 
@@ -482,7 +528,13 @@ export default function ChatBox({
 
       if (current.role !== "assistant" || !currentBot) {
         rows.push(
-          <MessageBubble key={current.id} role={current.role} content={current.content} bot={current.bot} />,
+          <MessageBubble
+            key={current.id}
+            role={current.role}
+            content={current.content}
+            bot={current.bot}
+            onLinkClick={current.role === "assistant" && quizId === "links" ? handleLinkClick : undefined}
+          />,
         );
         continue;
       }
@@ -501,12 +553,12 @@ export default function ChatBox({
         <div key={`pair-${pair.A?.id ?? "none"}-${pair.B?.id ?? "none"}`} className="grid grid-cols-2 gap-3">
           <div>
             {pair.A ? (
-              <MessageBubble role="assistant" content={pair.A.content} bot="A" assistantAlign="left" showLabel labelAlign="center" />
+              <MessageBubble role="assistant" content={pair.A.content} bot="A" assistantAlign="left" showLabel labelAlign="center" onLinkClick={quizId === "links" ? handleLinkClick : undefined} />
             ) : null}
           </div>
           <div>
             {pair.B ? (
-              <MessageBubble role="assistant" content={pair.B.content} bot="B" assistantAlign="right" showLabel labelAlign="center" />
+              <MessageBubble role="assistant" content={pair.B.content} bot="B" assistantAlign="right" showLabel labelAlign="center" onLinkClick={quizId === "links" ? handleLinkClick : undefined} />
             ) : null}
           </div>
         </div>,

--- a/frontend/components/MarkdownMessage.tsx
+++ b/frontend/components/MarkdownMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -162,13 +162,14 @@ const schema = {
   },
 };
 
-function makeComponents(dark: boolean) {
+function makeComponents(dark: boolean, onLinkClick?: (href: string) => void) {
   return {
     a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
       <a
         href={href}
         target="_blank"
         rel="noreferrer"
+        onClick={() => { if (href) onLinkClick?.(href); }}
         className={dark ? "text-white underline opacity-90 hover:opacity-100" : "text-blue-600 underline hover:text-blue-800"}
       >
         {children}
@@ -226,17 +227,28 @@ function makeComponents(dark: boolean) {
   };
 }
 
-const components = makeComponents(false);
-const darkComponents = makeComponents(true);
-
-const inlineComponents = {
-  ...components,
-  p: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
-};
-
-export default function MarkdownMessage({ content, inline = false, dark = false }: Readonly<{ content: string; inline?: boolean; dark?: boolean }>) {
+export default function MarkdownMessage({
+  content,
+  inline = false,
+  dark = false,
+  onLinkClick,
+}: Readonly<{
+  content: string;
+  inline?: boolean;
+  dark?: boolean;
+  onLinkClick?: (href: string) => void;
+}>) {
   const wrapped_content = wrapExpressions(content);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const baseComponents = useMemo(() => makeComponents(dark, onLinkClick), [dark, onLinkClick]);
+  const activeComponents = useMemo(() => {
+    if (!inline) return baseComponents;
+    return {
+      ...baseComponents,
+      p: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    };
+  }, [inline, baseComponents]);
 
   // Scale down display math blocks that are wider than their container so they
   // never overflow the chat bubble — even when the user changes browser zoom.
@@ -270,9 +282,6 @@ export default function MarkdownMessage({ content, inline = false, dark = false 
     fitMath();
     return () => ro.disconnect();
   }, [wrapped_content, inline]);
-
-  let activeComponents = dark ? darkComponents : components;
-  if (inline) activeComponents = inlineComponents;
 
   const rendered = (
     <ReactMarkdown

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -19,6 +19,8 @@ export type User = {
   consent_given_at?: string;
   consent_text?: string;
   consent_agreed_at?: string;
+  consent_declined_at?: string;
+  last_active_at?: string;
   is_admin: boolean;
   assigned_var?: string | null;
   demographics_completed?: boolean;
@@ -94,6 +96,13 @@ export async function logout() {
 
 export async function recordConsentAgreement(consentText: string) {
   return apiFetch<{ ok: boolean }>("/auth/consent", {
+    method: "POST",
+    body: JSON.stringify({ consent_text: consentText }),
+  });
+}
+
+export async function recordConsentDecline(consentText: string) {
+  return apiFetch<{ ok: boolean }>("/auth/decline", {
     method: "POST",
     body: JSON.stringify({ consent_text: consentText }),
   });

--- a/frontend/lib/chat.ts
+++ b/frontend/lib/chat.ts
@@ -49,6 +49,8 @@ export async function loadUserHistory(conversationId: string): Promise<{
   return apiFetch(`/api/chat/load_user_history/${conversationId}`);
 }
 
+export type ChatTrigger = "manual" | "followup_chip" | "auto_question";
+
 export interface SendChatOptions {
   signal?: AbortSignal;
   onToken?: (delta: string, agent?: string) => void;
@@ -56,6 +58,8 @@ export interface SendChatOptions {
   onFollowupToken?: (delta: string) => void;
   answerIncorrectly?: boolean;
   answerChoices?: { id: string; label: string }[];
+  questionId?: string;
+  trigger?: ChatTrigger;
 }
 
 export async function sendChat(
@@ -65,7 +69,7 @@ export async function sendChat(
   agents: string[] = [],
   options: SendChatOptions = {},
 ): Promise<ChatResponse> {
-  const { signal, onToken, onDone, onFollowupToken, answerIncorrectly, answerChoices } = options;
+  const { signal, onToken, onDone, onFollowupToken, answerIncorrectly, answerChoices, questionId, trigger } = options;
   const resp = await fetch(`/api/chat/${quizId}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -77,6 +81,8 @@ export async function sendChat(
       agents,
       answer_incorrectly: answerIncorrectly ?? false,
       answer_choices: (answerChoices ?? []).map((c) => ({ id: c.id, label: c.label })),
+      question_id: questionId ?? null,
+      trigger: trigger ?? null,
     }),
   });
 

--- a/frontend/lib/copyEvents.ts
+++ b/frontend/lib/copyEvents.ts
@@ -1,0 +1,28 @@
+// frontend/lib/copyEvents.ts
+import { apiFetch } from "./fetcher";
+
+export interface CopyEvent {
+  id: string;
+  user_id: string;
+  user_email: string;
+  quiz_id: string | null;
+  question_id: string | null;
+  conversation_id: string | null;
+  copied_text: string;
+  created_at: string;
+}
+
+const BASE = "/api/copy-events";
+
+export function recordCopyEvent(data: {
+  quiz_id?: string;
+  question_id?: string;
+  conversation_id?: string;
+  copied_text: string;
+}): Promise<CopyEvent> {
+  return apiFetch(BASE, { method: "POST", body: JSON.stringify(data) });
+}
+
+export function getCopyEvents(): Promise<CopyEvent[]> {
+  return apiFetch(BASE);
+}

--- a/frontend/lib/linkClicks.ts
+++ b/frontend/lib/linkClicks.ts
@@ -1,0 +1,28 @@
+// frontend/lib/linkClicks.ts
+import { apiFetch } from "./fetcher";
+
+export interface LinkClick {
+  id: string;
+  user_id: string;
+  user_email: string;
+  quiz_id: string | null;
+  question_id: string | null;
+  conversation_id: string | null;
+  url: string;
+  clicked_at: string;
+}
+
+const BASE = "/api/links/clicks";
+
+export function recordLinkClick(data: {
+  quiz_id?: string;
+  question_id?: string;
+  conversation_id?: string;
+  url: string;
+}): Promise<LinkClick> {
+  return apiFetch(BASE, { method: "POST", body: JSON.stringify(data) });
+}
+
+export function getLinkClicks(): Promise<LinkClick[]> {
+  return apiFetch(BASE);
+}

--- a/frontend/pages/consent.tsx
+++ b/frontend/pages/consent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
-import { getMe, invalidateMeCache, logout, recordConsentAgreement } from "../lib/auth";
+import { getMe, invalidateMeCache, logout, recordConsentAgreement, recordConsentDecline } from "../lib/auth";
 
 export default function ConsentPage() {
   const router = useRouter();
@@ -38,17 +38,19 @@ export default function ConsentPage() {
     );
   }
 
+  function getConsentText(): string {
+    return (consentContentRef.current?.textContent ?? "")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
   async function onAgree() {
     if (pending) return;
     setPending(true);
     setError(null);
 
-    const consentText = (consentContentRef.current?.textContent ?? "")
-      .replace(/\s+/g, " ")
-      .trim();
-
     try {
-      await recordConsentAgreement(consentText);
+      await recordConsentAgreement(getConsentText());
       invalidateMeCache();
       router.push("/dashboard");
     } catch (e) {
@@ -61,6 +63,11 @@ export default function ConsentPage() {
   async function onDecline() {
     if (pending) return;
     setPending(true);
+    try {
+      await recordConsentDecline(getConsentText());
+    } catch {
+      // Declining must still succeed from the user's POV even if this write fails.
+    }
     try {
       await logout();
     } catch {

--- a/frontend/pages/quiz/[quiz_id].tsx
+++ b/frontend/pages/quiz/[quiz_id].tsx
@@ -572,6 +572,7 @@ export default function QuizPage() {
                         onToggleQuestion={() => setQuestionCollapsed((c: boolean) => !c)}
                         answerIncorrectly={answerIncorrectly}
                         answerChoices={current?.choices}
+                        questionId={current?.id}
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Summary

- Tag every chat message with question_id and a trigger ("manual" / "followup_chip" / "auto_question") to link conversations back to the question that prompted them
- Detect which answer choice the AI's reply names (single- and dual-agent) and store it as stated_choice_id metadata, for comparing against what the participant actually submitted
- Track citation-link clicks in the links variant (url, question, timestamp)
- Track copy events anywhere in the chat pane (selected text + context)
- Add a last_active_at heartbeat (2-minute debounce) and an explicit consent-decline record (with the consent text shown) to capture attrition
- Add backend pytest coverage for all of the above, plus a backfill for the previously-untested reports feature; add matching frontend Jest coverage